### PR TITLE
feat(sgx.equinix.demo): enable SGX

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -402,6 +402,12 @@
           oidc.client.demo.equinix.sgx
           "staging"
           [
+            (mkDataServiceModule ''
+              chmod 0700 /var/lib/pccs
+              chmod 0600 /var/lib/pccs/api-key
+
+              chown -R root:pccs /var/lib/pccs
+            '')
             ({...}: {
               imports = [
                 ./hosts/sgx.equinix.demo.enarx.dev

--- a/hosts/sgx.equinix.demo.enarx.dev/default.nix
+++ b/hosts/sgx.equinix.demo.enarx.dev/default.nix
@@ -13,6 +13,11 @@
   fileSystems."/".device = "/dev/disk/by-id/ata-MTFDDAV240TDU_220133CB3E88-part3";
   fileSystems."/boot/efi".device = "/dev/disk/by-id/ata-MTFDDAV240TDU_220133CB3E88-part1";
 
+  hardware.cpu.intel.sgx.aesmd.enable = true;
+  hardware.cpu.intel.sgx.provision.enable = true;
+  hardware.cpu.intel.sgx.provision.service.apiKey = "/var/lib/pccs/api-key";
+  hardware.cpu.intel.sgx.provision.service.enable = true;
+
   networking.hostId = "395c78d1";
   networking.interfaces.eno12399.useDHCP = true;
   networking.interfaces.eno12409.useDHCP = true;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./common.nix
+    ./sgx.nix
     ./users.nix
   ];
 }

--- a/modules/sgx.nix
+++ b/modules/sgx.nix
@@ -1,0 +1,139 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.hardware.cpu.intel.sgx;
+
+  backend = config.virtualisation.oci-containers.backend;
+
+  aesmdService = "${backend}-aesmd";
+
+  aesmdImageName = "registry.gitlab.com/enarx/aesmd";
+  aesmd = pkgs.dockerTools.pullImage {
+    imageName = aesmdImageName;
+    imageDigest = "sha256:7d9016e8a274b2873d99b21ef34b8db1c869c0c96edad68e53efd7688561fa1a";
+    sha256 = "11205ka4ws2mv4788fhbilzgq31ag4swsc3r7bkkzz9gqq74i7l2";
+  };
+
+  defaultAesmdGroup = "aesmd";
+
+  pccsService = "${backend}-pccs";
+
+  pccsImageName = "registry.gitlab.com/haraldh/pccs";
+  pccs = pkgs.dockerTools.pullImage {
+    imageName = pccsImageName;
+    imageDigest = "sha256:b0729c0588a124c23d1c8d53d1ccd4f3d4ac099afc46e3fa8e5e0da9738bc760";
+    sha256 = "0xgxq82j3x2j21m2xzq5rwckn28n9ym6cfivaxadry6a9wpi40xr";
+    finalImageTag = "working";
+  };
+
+  defaultPccsGroup = "pccs";
+in
+  with lib; {
+    options.hardware.cpu.intel.sgx.aesmd = {
+      enable = mkEnableOption "Intel SGX Attestation Daemon service.";
+      user = mkOption {
+        type = types.str;
+        default = "root";
+        description = "User to run the Intel SGX Attestation Daemon service as.";
+      };
+      group = mkOption {
+        type = types.str;
+        default = defaultAesmdGroup;
+        description = "Group to run the Intel SGX Attestation Daemon service as.";
+      };
+    };
+
+    options.hardware.cpu.intel.sgx.provision.service = {
+      enable = mkEnableOption "Intel SGX Provisioning Certification service.";
+      user = mkOption {
+        type = types.str;
+        default = "root";
+        description = "User to run the Intel SGX Provisioning Certification service as.";
+      };
+      group = mkOption {
+        type = types.str;
+        default = defaultPccsGroup;
+        description = "Group to run the Intel SGX Provisioning Certification service as.";
+      };
+      apiKey = mkOption {
+        type = types.str;
+        description = "Path to SGX API key.";
+      };
+    };
+
+    config = mkMerge [
+      (mkIf cfg.aesmd.enable {
+        assertions = [
+          {
+            assertion = hasAttr cfg.aesmd.user config.users.users;
+            message = "Given user does not exist";
+          }
+          {
+            assertion = (cfg.aesmd.group == defaultAesmdGroup) || (hasAttr cfg.aesmd.group config.users.groups);
+            message = "Given group does not exist";
+          }
+        ];
+
+        systemd.services.${aesmdService} = {
+          serviceConfig.Group = cfg.aesmd.group;
+          serviceConfig.LimitMEMLOCK = "8G";
+          serviceConfig.Restart = "always";
+          serviceConfig.Type = "exec";
+          serviceConfig.User = cfg.aesmd.user;
+        };
+
+        users.groups = optionalAttrs (cfg.aesmd.group == defaultAesmdGroup) {
+          "${cfg.aesmd.group}" = {};
+        };
+
+        virtualisation.oci-containers.containers.aesmd.extraOptions = ["--device=/dev/sgx_enclave"];
+        virtualisation.oci-containers.containers.aesmd.image = aesmdImageName;
+        virtualisation.oci-containers.containers.aesmd.imageFile = aesmd;
+        virtualisation.oci-containers.containers.aesmd.volumes = [
+          "/dev/sgx_enclave:/dev/sgx/enclave"
+          "/dev/sgx_provision:/dev/sgx/provision"
+          "/var/run/aesmd:/var/run/aesmd"
+        ];
+      })
+      (mkIf cfg.provision.service.enable {
+        assertions = [
+          {
+            assertion = hasAttr cfg.provision.service.user config.users.users;
+            message = "Given user does not exist";
+          }
+          {
+            assertion = (cfg.provision.service.group == defaultPccsGroup) || (hasAttr cfg.provision.service.group config.users.groups);
+            message = "Given group does not exist";
+          }
+        ];
+
+        systemd.services.${pccsService} = {
+          preStart = ''
+            ${backend} secret create PCCS_APIKEY ${cfg.provision.service.apiKey}
+          '';
+          postStop = ''
+            ${backend} secret rm PCCS_APIKEY
+          '';
+          serviceConfig.Group = cfg.provision.service.group;
+          serviceConfig.LimitMEMLOCK = "8G";
+          serviceConfig.Restart = "always";
+          serviceConfig.Type = "exec";
+          serviceConfig.User = cfg.provision.service.user;
+        };
+
+        users.groups = optionalAttrs (cfg.provision.service.group == defaultPccsGroup) {
+          "${cfg.provision.service.group}" = {};
+        };
+
+        virtualisation.oci-containers.containers.pccs.extraOptions = [
+          "--network=host"
+          "--secret=PCCS_APIKEY,type=mount"
+        ];
+        virtualisation.oci-containers.containers.pccs.image = pccsImageName;
+        virtualisation.oci-containers.containers.pccs.imageFile = pccs;
+      })
+    ];
+  }


### PR DESCRIPTION
```
$ ssh sgx.equinix.demo.enarx.dev sudo enarx platform info           
Enarx version 0.6.0
System Info: Linux 5.18.0-rc3-next-20220422 #1-NixOS SMP PREEMPT_DYNAMIC Thu Jul 7 06:12:49 UTC 2022 x86_64
✔ Backend: sgx
  ✔ Driver: /dev/sgx_enclave
  ✔ AESM Daemon Socket: /var/run/aesmd/aesm.socket
  ✔ CPU: Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz | GenuineIntel
  ✔  SGX Support
  ✔   Version 1
  ✔   Version 2
  ✔   FLC Support
  ✔   Max Size (32-bit): 2 GiB
  ✔   Max Size (64-bit): 64 PiB
  ✔   MiscSelect: EXINFO
  ✔   Features: DEBUG | MODE64BIT | PROVISIONING_KEY | EINIT_KEY | KSS
  ✔   Xfrm: X87 | SSE | AVX | YMM | OPMASK | ZMM_HI256 | HI16_ZMM | MPK
  ✔   EPC Size: 7 GiB
✗ Backend: sev
  ✗ Driver: /dev/sev
  ✔  SEV-SNP is enabled in host kernel
  ✗  /dev/sev is readable by user
  ✗  /dev/sev is writable by user
  ✔ Driver: /dev/kvm
  ✔  API Version: 12
  ✔ MEMLOCK rlimit allows for: ~1 keep (soft limit = 8388608 bytes, hard limit = 8388608 bytes)
  ✗ CPU: Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz | GenuineIntel
  ✗  Microcode support
  ✗  Secure Memory Encryption (SME)
  ✗   Physical address bit reduction
  ✗   C-bit location in page table entry
  ✗  Secure Encrypted Virtualization (SEV)
  ✗   Number of encrypted guests supported simultaneously
  ✗   Minimum ASID value for SEV-enabled, SEV-ES disabled guest
  ✗  Secure Encrypted Virtualization Secure Nested Paging (SEV-SNP)
  ✗  Page Flush MSR available
✔ Backend: kvm
  ✔ Driver: /dev/kvm
  ✔  API Version: 12
  ✔ CPU: Intel(R) Xeon(R) Gold 6338 CPU @ 2.00GHz | GenuineIntel
  ✔  CPU supports FSGSBASE instructions
  ✔  CPU supports RDRAND instruction
✔ Backend: nil
```