### PR TITLE
feat(sgx.equinix.demo): use upstream `aesmd`

### DIFF
--- a/hosts/sgx.equinix.demo.enarx.dev/default.nix
+++ b/hosts/sgx.equinix.demo.enarx.dev/default.nix
@@ -13,7 +13,6 @@
   fileSystems."/".device = "/dev/disk/by-id/ata-MTFDDAV240TDU_220133CB3E88-part3";
   fileSystems."/boot/efi".device = "/dev/disk/by-id/ata-MTFDDAV240TDU_220133CB3E88-part1";
 
-  hardware.cpu.intel.sgx.aesmd.enable = true;
   hardware.cpu.intel.sgx.provision.enable = true;
   hardware.cpu.intel.sgx.provision.service.apiKey = "/var/lib/pccs/api-key";
   hardware.cpu.intel.sgx.provision.service.enable = true;
@@ -25,6 +24,9 @@
   networking.interfaces.eno12429.useDHCP = true;
 
   nix.maxJobs = lib.mkDefault 128;
+
+  services.aesmd.enable = true;
+  systemd.services.aesmd.serviceConfig.LimitMEMLOCK = "8G";
 
   swapDevices = [
     {device = "/dev/disk/by-id/ata-MTFDDAV240TDU_220133CB3E88-part2";}


### PR DESCRIPTION
Use upstream `aesmd` module to reduce the amount of code we need to maintain, benefit from updates and pretty solid, reviewed, config https://github.com/NixOS/nixpkgs/blob/71d7a4c037dc4f3e98d5c4a81b941933cf5bf675/nixos/modules/services/security/aesmd.nix#L114-L233