### PR TITLE
refactor: split flake into multiple components

### DIFF
--- a/deploy/default.nix
+++ b/deploy/default.nix
@@ -1,0 +1,21 @@
+{
+  self,
+  deploy-rs,
+  ...
+}: let
+  mkDeployNode = nixos: {
+    hostname = nixos.config.networking.fqdn;
+    profiles.system.path = deploy-rs.lib.${nixos.config.nixpkgs.system}.activate.nixos nixos;
+    profiles.system.sshUser = "deploy";
+    profiles.system.user = "root";
+  };
+in {
+  nodes.attest = mkDeployNode self.nixosConfigurations.attest;
+  nodes.attest-staging = mkDeployNode self.nixosConfigurations.attest-staging;
+  nodes.attest-testing = mkDeployNode self.nixosConfigurations.attest-testing;
+  nodes.sgx-equinix-demo = mkDeployNode self.nixosConfigurations.sgx-equinix-demo;
+  nodes.snp-equinix-demo = mkDeployNode self.nixosConfigurations.snp-equinix-demo;
+  nodes.store = mkDeployNode self.nixosConfigurations.store;
+  nodes.store-staging = mkDeployNode self.nixosConfigurations.store-staging;
+  nodes.store-testing = mkDeployNode self.nixosConfigurations.store-testing;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1657809434,
-        "narHash": "sha256-MTmqJFO2Plt/+GAo0FLrPqf9qNa/kHCcIDC2zYwnm48=",
+        "lastModified": 1658348641,
+        "narHash": "sha256-JsMl2iS2xovxOhaRskNedIXZg+ezywBNE4RD0DQvtow=",
         "owner": "profianinc",
         "repo": "benefice",
-        "rev": "194d9e259b350e37269b45fc8b9989c59139eeb7",
+        "rev": "38d0c19e05cb8f2b0602a4d8ac87fbf36f418edb",
         "type": "github"
       },
       "original": {
@@ -328,11 +328,11 @@
     },
     "nixlib": {
       "locked": {
-        "lastModified": 1636849918,
-        "narHash": "sha256-nzUK6dPcTmNVrgTAC1EOybSMsrcx+QrVPyqRdyKLkjA=",
+        "lastModified": 1658019594,
+        "narHash": "sha256-mDy+kslt3q+LGnu2Ljlx6wsdZTIK163TBQX1ibGqKGc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "28a5b0557f14124608db68d3ee1f77e9329e9dd5",
+        "rev": "153065e985316db9b6aa78f319d81163711c44fd",
         "type": "github"
       },
       "original": {
@@ -343,7 +343,9 @@
     },
     "nixos-generators": {
       "inputs": {
-        "nixlib": "nixlib",
+        "nixlib": [
+          "nixlib"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -465,6 +467,7 @@
         "enarx": "enarx",
         "flake-compat": "flake-compat_3",
         "flake-utils": "flake-utils_3",
+        "nixlib": "nixlib",
         "nixos-generators": "nixos-generators",
         "nixpkgs": "nixpkgs_4",
         "sops-nix": "sops-nix",
@@ -573,11 +576,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1658030499,
-        "narHash": "sha256-Y2Me+uys8VpKUincd7T3ab8O4gBFv8bR5BmBZfn4i4w=",
+        "lastModified": 1658398472,
+        "narHash": "sha256-DjPJ3YQXyV1GRvF3ToBIY+RYdypwNxYchN1HIhDPLe0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "7526ce07b897ad1f1016680de5121f646e28a893",
+        "rev": "6efa719f8d02139ce41398b9e59e06888dc1305a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,8 @@
   inputs.flake-compat.flake = false;
   inputs.flake-compat.url = github:edolstra/flake-compat;
   inputs.flake-utils.url = github:numtide/flake-utils;
+  inputs.nixlib.url = "github:nix-community/nixpkgs.lib";
+  inputs.nixos-generators.inputs.nixlib.follows = "nixlib";
   inputs.nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
   inputs.nixos-generators.url = github:nix-community/nixos-generators;
   inputs.nixpkgs.url = github:profianinc/nixpkgs;
@@ -28,446 +30,63 @@
   inputs.steward-staging.url = "https://github.com/profianinc/steward/releases/download/v0.1.0/steward-x86_64-unknown-linux-musl";
   inputs.steward-testing.url = github:profianinc/steward;
 
-  outputs = {
+  outputs = inputs @ {
     self,
-    benefice-staging,
-    benefice-testing,
     deploy-rs,
-    drawbridge-production,
-    drawbridge-staging,
-    drawbridge-testing,
-    enarx,
-    flake-compat,
     flake-utils,
     nixos-generators,
     nixpkgs,
-    sops-nix,
-    steward-production,
-    steward-staging,
-    steward-testing,
-  }: let
-    sshUser = "deploy";
+    ...
+  }:
+    with flake-utils.lib.system; let
+      mkEnarxImage = pkgs: format: modules:
+        nixos-generators.nixosGenerate {
+          inherit format pkgs;
+          modules =
+            [
+              "${self}/modules/common.nix"
+              ({pkgs, ...}: {
+                networking.firewall.allowedTCPPorts = [
+                  80
+                  443
+                ];
 
-    emails.ops = "roman@profian.com"; # TODO: How about ops@profian.com ?
-
-    oidc.client.demo.equinix.sgx = "23Lt09AjF8HpUeCCwlfhuV34e2dKD1MH";
-    oidc.client.demo.equinix.snp = "Ayrct2YbMF6OHFN8bzpv3XemWI3ca5Hk";
-
-    oidc.client.testing.benefice = "FTmeUMamlu8HRs11mvtmmZHnmCwRIo8E";
-    oidc.client.testing.store = "zFrR7MKMakS4OpEflR0kNw3ceoP7sr3s";
-
-    oidc.client.staging.store = "9SVWiB3sQQdzKqpZmMNvsb9rzd8Ha21F";
-
-    oidc.client.production.store = "2vq9XnQgcGZ9JCxsGERuGURYIld3mcIh";
-
-    serviceOverlay = self: super: let
-      fromInput = name: src:
-        self.stdenv.mkDerivation {
-          inherit name;
-          phases = ["installPhase"];
-          installPhase = ''
-            mkdir -p $out/bin
-            install ${src} $out/bin/${name}
-          '';
+                nixpkgs.overlays = [self.overlays.service];
+                services.enarx.enable = true;
+              })
+            ]
+            ++ modules;
         };
-    in {
-      benefice.testing = benefice-testing.packages.x86_64-linux.benefice-debug-x86_64-unknown-linux-musl;
-      benefice.staging = fromInput "benefice" benefice-staging;
 
-      drawbridge.testing = drawbridge-testing.packages.x86_64-linux.drawbridge-debug-x86_64-unknown-linux-musl;
-      drawbridge.staging = fromInput "drawbridge" drawbridge-staging;
-      drawbridge.production = fromInput "drawbridge" drawbridge-production;
-
-      enarx = fromInput "enarx" enarx;
-
-      steward.testing = steward-testing.packages.x86_64-linux.steward-x86_64-unknown-linux-musl;
-      steward.staging = fromInput "steward" steward-staging;
-      steward.production = fromInput "steward" steward-production;
-    };
-
-    exposeKey = pkgs: user: key:
-      pkgs.writeShellScript "expose-${key}.sh" ''
-        chmod 0400 "${key}"
-        chown ${user}:${user} "${key}"
-      '';
-
-    hideKey = pkgs: user: key:
-      pkgs.writeShellScript "hide-${key}.sh" ''
-        chmod 0000 "${key}"
-        chown ${user}:${user} "${key}"
-      '';
-
-    mkHost = system: modules:
-      nixpkgs.lib.nixosSystem {
-        inherit system;
-
-        modules =
-          [
-            ./modules
-            ({config, ...}: {
-              networking.firewall.allowedTCPPorts = [
-                80
-                443
+      mkEnarxSevImage = pkgs: format: modules:
+        mkEnarxImage pkgs format ([
+            {
+              boot.kernelModules = [
+                "kvm-amd"
               ];
+              boot.kernelPackages = pkgs.linuxPackages_enarx;
 
-              nix.settings.allowed-users = with config.users; [
-                "@${groups.deploy.name}"
-              ];
-              nix.settings.trusted-users = with config.users; [
-                "@${groups.deploy.name}"
-              ];
-              nixpkgs.overlays = [serviceOverlay];
+              hardware.cpu.amd.sev.enable = true;
+              hardware.cpu.amd.sev.mode = "0777";
 
-              security.acme.defaults.email = emails.ops;
-            })
+              hardware.cpu.amd.updateMicrocode = true;
+
+              services.enarx.backend = "sev";
+            }
           ]
-          ++ modules;
-      };
-
-    mkService = base: system: modules: mkHost system (base ++ modules);
-
-    mkBenefice = mkService [
-      sops-nix.nixosModules.sops
-      ({
-        config,
-        lib,
-        pkgs,
-        ...
-      }: {
-        networking.firewall.enable = lib.mkForce false;
-
-        services.benefice.enable = true;
-        services.benefice.oidc.secretFile = config.sops.secrets.oidc-secret.path;
-
-        sops.age.sshKeyPaths = ["/etc/ssh/ssh_host_ed25519_key"];
-        sops.secrets.oidc-secret.format = "binary";
-        sops.secrets.oidc-secret.mode = "0000";
-        sops.secrets.oidc-secret.restartUnits = ["benefice.service"];
-
-        systemd.services.benefice.serviceConfig.ExecStartPre = "+${exposeKey pkgs "benefice" config.sops.secrets.oidc-secret.path}";
-        systemd.services.benefice.serviceConfig.ExecStop = "+${hideKey pkgs config.users.users.root.name config.sops.secrets.oidc-secret.path}";
-        systemd.services.benefice.serviceConfig.SupplementaryGroups = [config.users.groups.keys.name];
-      })
-    ];
-
-    mkDrawbridge = mkService [
+          ++ modules);
+    in
       {
-        services.drawbridge.enable = true;
-      }
-    ];
-
-    mkSteward = mkService [
-      sops-nix.nixosModules.sops
-      ({
-        config,
-        pkgs,
-        ...
-      }: {
-        services.steward.enable = true;
-        services.steward.keyFile = config.sops.secrets.key.path;
-
-        sops.age.sshKeyPaths = ["/etc/ssh/ssh_host_ed25519_key"];
-        sops.secrets.key.format = "binary";
-        sops.secrets.key.mode = "0000";
-        sops.secrets.key.restartUnits = ["steward.service"];
-
-        systemd.services.steward.serviceConfig.ExecStartPre = "+${exposeKey pkgs "steward" config.sops.secrets.key.path}";
-        systemd.services.steward.serviceConfig.ExecStop = "+${hideKey pkgs config.users.users.root.name config.sops.secrets.key.path}";
-        systemd.services.steward.serviceConfig.SupplementaryGroups = [config.users.groups.keys.name];
-      })
-    ];
-
-    mkEnarxImage = pkgs: format: modules:
-      nixos-generators.nixosGenerate {
-        inherit format pkgs;
-        modules =
-          [
-            ./modules/common.nix
-            ({pkgs, ...}: {
-              networking.firewall.allowedTCPPorts = [
-                80
-                443
-              ];
-
-              nixpkgs.overlays = [serviceOverlay];
-              services.enarx.enable = true;
-            })
-          ]
-          ++ modules;
-      };
-
-    mkEnarxSevImage = pkgs: format: modules:
-      mkEnarxImage pkgs format ([
-          {
-            boot.kernelModules = [
-              "kvm-amd"
-            ];
-            boot.kernelPackages = pkgs.linuxPackages_enarx;
-
-            hardware.cpu.amd.sev.enable = true;
-            hardware.cpu.amd.sev.mode = "0777";
-
-            hardware.cpu.amd.updateMicrocode = true;
-
-            services.enarx.backend = "sev";
-          }
-        ]
-        ++ modules);
-
-    hostKey = pkgs: let
-      grep = "${pkgs.gnugrep}/bin/grep";
-      ssh-keyscan = "${pkgs.openssh}/bin/ssh-keyscan";
-      ssh-to-age = "${pkgs.ssh-to-age}/bin/ssh-to-age";
-    in
-      pkgs.writeShellScriptBin "host-key" ''
-        set -e
-
-        ${ssh-keyscan} "''${1}" 2> /dev/null | ${grep} 'ssh-ed25519' | ${ssh-to-age}
-      '';
-
-    bootstrapCA = pkgs: let
-      key = ''"ca/''${1}/ca.key"'';
-      crt = ''"ca/''${1}/ca.crt"'';
-      conf = pkgs.writeText "ca.conf" ''
-        [req]
-        distinguished_name = req_distinguished_name
-        prompt = no
-        x509_extensions = v3_ca
-
-        [req_distinguished_name]
-        C   = US
-        ST  = North Carolina
-        L   = Raleigh
-        CN  = Proof of Concept
-
-        [v3_ca]
-        basicConstraints = critical,CA:TRUE
-        keyUsage = cRLSign, keyCertSign
-        nsComment = "Profian CA certificate"
-        subjectKeyIdentifier = hash
-      '';
-
-      openssl = "${pkgs.openssl}/bin/openssl";
-      sops = "${pkgs.sops}/bin/sops";
-    in
-      pkgs.writeShellScriptBin "bootstrap-ca" ''
-        set -xe
-
-        umask 0077
-
-        ${openssl} ecparam -genkey -name prime256v1 | ${openssl} pkcs8 -topk8 -nocrypt -out ${key}
-        ${openssl} req -new -x509 -days 365 -config ${conf} -key ${key} -out ${crt}
-        ${sops} -e -i ${key}
-      '';
-
-    bootstrapSteward = pkgs: let
-      ca.key = ''"ca/''${1}/ca.key"'';
-      ca.crt = ''"ca/''${1}/ca.crt"'';
-
-      steward.key = ''"hosts/attest.''${1}/steward.key"'';
-      steward.csr = ''"hosts/attest.''${1}/steward.csr"'';
-      steward.crt = ''"hosts/attest.''${1}/steward.crt"'';
-
-      conf = pkgs.writeText "steward.conf" ''
-        [req]
-        distinguished_name = req_distinguished_name
-        prompt = no
-        x509_extensions = v3_ca
-
-        [req_distinguished_name]
-        C   = US
-        ST  = North Carolina
-        L   = Raleigh
-        CN  = Proof of Concept
-
-        [v3_ca]
-        basicConstraints = critical,CA:TRUE
-        keyUsage = cRLSign, keyCertSign
-        nsComment = "Profian attestation service CA certificate"
-        subjectKeyIdentifier = hash
-      '';
-
-      openssl = "${pkgs.openssl}/bin/openssl";
-      sops = "${pkgs.sops}/bin/sops";
-
-      sign-cert = "${pkgs.writeShellScriptBin "sign-cert" ''
-        set -xe
-
-        ${openssl} x509 -req -days 365 -CAcreateserial -CA ${ca.crt} -CAkey "''${2}" -in ${steward.csr} -out ${steward.crt} -extfile ${conf} -extensions v3_ca
-      ''}/bin/sign-cert";
-    in
-      pkgs.writeShellScriptBin "bootstrap-steward" ''
-        set -xe
-
-        umask 0077
-
-        ${openssl} ecparam -genkey -name prime256v1 | ${openssl} pkcs8 -topk8 -nocrypt -out ${steward.key}
-        ${openssl} req -new -config ${conf} -key ${steward.key} -out ${steward.csr}
-        ${sops} -e -i ${steward.key}
-
-        ${sops} exec-file ${ca.key} "${sign-cert} \"''${1}\" {}"
-      '';
-
-    bootstrap = pkgs: let
-      bootstrap-ca = "${pkgs.bootstrap-ca}/bin/bootstrap-ca";
-      bootstrap-steward = "${pkgs.bootstrap-steward}/bin/bootstrap-steward";
-    in
-      pkgs.writeShellScriptBin "bootstrap" ''
-        set -e
-
-        for host in ca/*; do
-            ${bootstrap-ca} "''${host#'ca/'}"
-        done
-
-        for host in hosts/attest.*; do
-            ${bootstrap-steward} "''${host#'hosts/attest.'}"
-        done
-      '';
-
-    toolingOverlay = self: super: {
-      bootstrap = bootstrap self;
-      bootstrap-ca = bootstrapCA self;
-      bootstrap-steward = bootstrapSteward self;
-      host-key = hostKey self;
-    };
-
-    mkDeployNode = system: nixos: {
-      hostname = nixos.config.networking.fqdn;
-      profiles.system.path = deploy-rs.lib.${system}.activate.nixos nixos;
-      profiles.system.sshUser = sshUser;
-      profiles.system.user = "root";
-    };
-  in
-    with flake-utils.lib.system;
-      {
-        nixosConfigurations.sgx-equinix-demo = mkBenefice x86_64-linux [
-          ({pkgs, ...}: {
-            imports = [
-              ./hosts/sgx.equinix.demo.enarx.dev
-            ];
-
-            services.benefice.log.level = "info";
-            services.benefice.oidc.client = oidc.client.demo.equinix.sgx;
-            services.benefice.package = pkgs.benefice.staging;
-
-            sops.secrets.oidc-secret.sopsFile = ./hosts/sgx.equinix.demo.enarx.dev/oidc-secret;
-          })
-        ];
-
-        nixosConfigurations.snp-equinix-demo = mkBenefice x86_64-linux [
-          ({pkgs, ...}: {
-            imports = [
-              ./hosts/snp.equinix.demo.enarx.dev
-            ];
-
-            services.benefice.log.level = "info";
-            services.benefice.oidc.client = oidc.client.demo.equinix.snp;
-            services.benefice.package = pkgs.benefice.staging;
-
-            sops.secrets.oidc-secret.sopsFile = ./hosts/snp.equinix.demo.enarx.dev/oidc-secret;
-          })
-        ];
-
-        nixosConfigurations.attest-staging = mkSteward x86_64-linux [
-          ({pkgs, ...}: {
-            imports = [
-              ./hosts/attest.staging.profian.com
-            ];
-
-            services.steward.certFile = "${./hosts/attest.staging.profian.com/steward.crt}";
-            services.steward.log.level = "info";
-            services.steward.package = pkgs.steward.staging;
-
-            sops.secrets.key.sopsFile = ./hosts/attest.staging.profian.com/steward.key;
-          })
-        ];
-
-        nixosConfigurations.attest-testing = mkSteward x86_64-linux [
-          ({pkgs, ...}: {
-            imports = [
-              ./hosts/attest.testing.profian.com
-            ];
-
-            services.steward.certFile = "${./hosts/attest.testing.profian.com/steward.crt}";
-            services.steward.log.level = "debug";
-            services.steward.package = pkgs.steward.testing;
-
-            sops.secrets.key.sopsFile = ./hosts/attest.testing.profian.com/steward.key;
-          })
-        ];
-
-        nixosConfigurations.attest = mkSteward x86_64-linux [
-          ({pkgs, ...}: {
-            imports = [
-              ./hosts/attest.profian.com
-            ];
-
-            services.steward.certFile = "${./hosts/attest.profian.com/steward.crt}";
-            services.steward.package = pkgs.steward.production;
-
-            sops.secrets.key.sopsFile = ./hosts/attest.profian.com/steward.key;
-          })
-        ];
-
-        nixosConfigurations.store-testing = mkDrawbridge x86_64-linux [
-          ({pkgs, ...}: {
-            imports = [
-              ./hosts/store.testing.profian.com
-            ];
-
-            services.drawbridge.log.level = "debug";
-            services.drawbridge.oidc.client = oidc.client.testing.store;
-            services.drawbridge.package = pkgs.drawbridge.testing;
-            services.drawbridge.tls.caFile = "${./ca/testing.profian.com/ca.crt}";
-          })
-        ];
-
-        nixosConfigurations.store-staging = mkDrawbridge x86_64-linux [
-          ({pkgs, ...}: {
-            imports = [
-              ./hosts/store.staging.profian.com
-            ];
-
-            services.drawbridge.log.level = "info";
-            services.drawbridge.oidc.client = oidc.client.staging.store;
-            services.drawbridge.package = pkgs.drawbridge.staging;
-            services.drawbridge.tls.caFile = "${./ca/staging.profian.com/ca.crt}";
-          })
-        ];
-
-        nixosConfigurations.store = mkDrawbridge x86_64-linux [
-          ({pkgs, ...}: {
-            imports = [
-              ./hosts/store.profian.com
-            ];
-
-            services.drawbridge.oidc.client = oidc.client.production.store;
-            services.drawbridge.package = pkgs.drawbridge.production;
-            services.drawbridge.tls.caFile = "${./ca/profian.com/ca.crt}";
-          })
-        ];
-
-        deploy.nodes.sgx-equinix-demo = mkDeployNode x86_64-linux self.nixosConfigurations.sgx-equinix-demo;
-        deploy.nodes.snp-equinix-demo = mkDeployNode x86_64-linux self.nixosConfigurations.snp-equinix-demo;
-
-        deploy.nodes.attest = mkDeployNode x86_64-linux self.nixosConfigurations.attest;
-        deploy.nodes.attest-staging = mkDeployNode x86_64-linux self.nixosConfigurations.attest-staging;
-        deploy.nodes.attest-testing = mkDeployNode x86_64-linux self.nixosConfigurations.attest-testing;
-
-        deploy.nodes.store = mkDeployNode x86_64-linux self.nixosConfigurations.store;
-        deploy.nodes.store-staging = mkDeployNode x86_64-linux self.nixosConfigurations.store-staging;
-        deploy.nodes.store-testing = mkDeployNode x86_64-linux self.nixosConfigurations.store-testing;
-
         checks = builtins.mapAttrs (system: deployLib: deployLib.deployChecks self.deploy) deploy-rs.lib;
+        deploy = import ./deploy inputs;
+        nixosConfigurations = import ./nixosConfigurations inputs;
+        overlays = import ./overlays inputs;
       }
       // flake-utils.lib.eachDefaultSystem (
         system: let
           pkgs = import nixpkgs {
             inherit system;
-            overlays = [
-              serviceOverlay
-              toolingOverlay
-            ];
+            overlays = [self.overlays.default];
           };
 
           enarx-sev-amazon = mkEnarxSevImage pkgs "amazon" [
@@ -477,16 +96,15 @@
               ec2.ena = false;
             }
           ];
-        in {
-          formatter = pkgs.alejandra;
 
           packages = pkgs.lib.optionalAttrs (system == x86_64-linux || system == aarch64-linux) {
             inherit enarx-sev-amazon;
           };
 
-          devShells.default = pkgs.mkShell {
+          devShell = pkgs.mkShell {
             nativeBuildInputs = [
               pkgs.age
+              pkgs.aws
               pkgs.nixUnstable
               pkgs.openssl
               pkgs.sops
@@ -500,6 +118,11 @@
               deploy-rs.packages.${system}.default
             ];
           };
+        in {
+          inherit packages;
+
+          formatter = pkgs.alejandra;
+          devShells.default = devShell;
         }
       );
 }

--- a/nixosConfigurations/default.nix
+++ b/nixosConfigurations/default.nix
@@ -1,0 +1,238 @@
+{
+  self,
+  flake-utils,
+  nixpkgs,
+  sops-nix,
+  ...
+}:
+with flake-utils.lib.system; let
+  emails.ops = "roman@profian.com"; # TODO: How about ops@profian.com ?
+
+  oidc.client.demo.equinix.sgx = "23Lt09AjF8HpUeCCwlfhuV34e2dKD1MH";
+  oidc.client.demo.equinix.snp = "Ayrct2YbMF6OHFN8bzpv3XemWI3ca5Hk";
+
+  oidc.client.testing.benefice = "FTmeUMamlu8HRs11mvtmmZHnmCwRIo8E";
+  oidc.client.testing.store = "zFrR7MKMakS4OpEflR0kNw3ceoP7sr3s";
+
+  oidc.client.staging.store = "9SVWiB3sQQdzKqpZmMNvsb9rzd8Ha21F";
+
+  oidc.client.production.store = "2vq9XnQgcGZ9JCxsGERuGURYIld3mcIh";
+
+  mkHost = system: modules:
+    nixpkgs.lib.nixosSystem {
+      inherit system;
+
+      modules =
+        [
+          "${self}/modules"
+          ({config, ...}: {
+            networking.firewall.allowedTCPPorts = [
+              80
+              443
+            ];
+
+            nix.settings.allowed-users = with config.users; [
+              "@${groups.deploy.name}"
+            ];
+            nix.settings.trusted-users = with config.users; [
+              "@${groups.deploy.name}"
+            ];
+            nixpkgs.overlays = [self.overlays.service];
+
+            security.acme.defaults.email = emails.ops;
+          })
+        ]
+        ++ modules;
+    };
+
+  mkService = base: system: modules: mkHost system (base ++ modules);
+
+  exposeKey = pkgs: user: key:
+    pkgs.writeShellScript "expose-${key}.sh" ''
+      chmod 0400 "${key}"
+      chown ${user}:${user} "${key}"
+    '';
+
+  hideKey = pkgs: user: key:
+    pkgs.writeShellScript "hide-${key}.sh" ''
+      chmod 0000 "${key}"
+      chown ${user}:${user} "${key}"
+    '';
+
+  mkBenefice = mkService [
+    sops-nix.nixosModules.sops
+    ({
+      config,
+      lib,
+      pkgs,
+      ...
+    }: {
+      networking.firewall.enable = lib.mkForce false;
+
+      services.benefice.enable = true;
+      services.benefice.oidc.secretFile = config.sops.secrets.oidc-secret.path;
+
+      sops.age.sshKeyPaths = ["/etc/ssh/ssh_host_ed25519_key"];
+      sops.secrets.oidc-secret.format = "binary";
+      sops.secrets.oidc-secret.mode = "0000";
+      sops.secrets.oidc-secret.restartUnits = ["benefice.service"];
+      sops.secrets.oidc-secret.sopsFile = "${self}/hosts/${config.networking.fqdn}/oidc-secret";
+
+      systemd.services.benefice.serviceConfig.ExecStartPre = "+${exposeKey pkgs "benefice" config.sops.secrets.oidc-secret.path}";
+      systemd.services.benefice.serviceConfig.ExecStop = "+${hideKey pkgs config.users.users.root.name config.sops.secrets.oidc-secret.path}";
+      systemd.services.benefice.serviceConfig.SupplementaryGroups = [config.users.groups.keys.name];
+    })
+  ];
+
+  sgx-equinix-demo = mkBenefice x86_64-linux [
+    ({
+      config,
+      pkgs,
+      ...
+    }: {
+      imports = [
+        "${self}/hosts/sgx.equinix.demo.enarx.dev"
+      ];
+
+      services.benefice.log.level = "info";
+      services.benefice.oidc.client = oidc.client.demo.equinix.sgx;
+      services.benefice.package = pkgs.benefice.staging;
+    })
+  ];
+
+  snp-equinix-demo = mkBenefice x86_64-linux [
+    ({
+      config,
+      pkgs,
+      ...
+    }: {
+      imports = [
+        "${self}/hosts/snp.equinix.demo.enarx.dev"
+      ];
+
+      services.benefice.log.level = "info";
+      services.benefice.oidc.client = oidc.client.demo.equinix.snp;
+      services.benefice.package = pkgs.benefice.staging;
+    })
+  ];
+
+  mkDrawbridge = mkService [
+    ({config, ...}: {
+      services.drawbridge.enable = true;
+      services.drawbridge.tls.caFile = "${"${self}/ca/${config.networking.fqdn}/ca.crt"}";
+    })
+  ];
+
+  store-testing = mkDrawbridge x86_64-linux [
+    ({pkgs, ...}: {
+      imports = [
+        "${self}/hosts/store.testing.profian.com"
+      ];
+
+      services.drawbridge.log.level = "debug";
+      services.drawbridge.oidc.client = oidc.client.testing.store;
+      services.drawbridge.package = pkgs.drawbridge.testing;
+    })
+  ];
+
+  store-staging = mkDrawbridge x86_64-linux [
+    ({pkgs, ...}: {
+      imports = [
+        "${self}/hosts/store.staging.profian.com"
+      ];
+
+      services.drawbridge.log.level = "info";
+      services.drawbridge.oidc.client = oidc.client.staging.store;
+      services.drawbridge.package = pkgs.drawbridge.staging;
+    })
+  ];
+
+  store = mkDrawbridge x86_64-linux [
+    ({pkgs, ...}: {
+      imports = [
+        "${self}/hosts/store.profian.com"
+      ];
+
+      services.drawbridge.oidc.client = oidc.client.production.store;
+      services.drawbridge.package = pkgs.drawbridge.production;
+    })
+  ];
+
+  mkSteward = mkService [
+    sops-nix.nixosModules.sops
+    ({
+      config,
+      pkgs,
+      ...
+    }: {
+      services.steward.certFile = "${"${self}/hosts/${config.networking.fqdn}/steward.crt"}";
+      services.steward.enable = true;
+      services.steward.keyFile = config.sops.secrets.key.path;
+
+      sops.age.sshKeyPaths = ["/etc/ssh/ssh_host_ed25519_key"];
+      sops.secrets.key.format = "binary";
+      sops.secrets.key.mode = "0000";
+      sops.secrets.key.restartUnits = ["steward.service"];
+      sops.secrets.key.sopsFile = "${self}/hosts/${config.networking.fqdn}/steward.key";
+
+      systemd.services.steward.serviceConfig.ExecStartPre = "+${exposeKey pkgs "steward" config.sops.secrets.key.path}";
+      systemd.services.steward.serviceConfig.ExecStop = "+${hideKey pkgs config.users.users.root.name config.sops.secrets.key.path}";
+      systemd.services.steward.serviceConfig.SupplementaryGroups = [config.users.groups.keys.name];
+    })
+  ];
+
+  attest-testing = mkSteward x86_64-linux [
+    ({
+      config,
+      pkgs,
+      ...
+    }: {
+      imports = [
+        "${self}/hosts/attest.testing.profian.com"
+      ];
+
+      services.steward.log.level = "debug";
+      services.steward.package = pkgs.steward.testing;
+    })
+  ];
+
+  attest-staging = mkSteward x86_64-linux [
+    ({
+      config,
+      pkgs,
+      ...
+    }: {
+      imports = [
+        "${self}/hosts/attest.staging.profian.com"
+      ];
+
+      services.steward.log.level = "info";
+      services.steward.package = pkgs.steward.staging;
+    })
+  ];
+
+  attest = mkSteward x86_64-linux [
+    ({
+      config,
+      pkgs,
+      ...
+    }: {
+      imports = [
+        "${self}/hosts/attest.profian.com"
+      ];
+
+      services.steward.package = pkgs.steward.production;
+    })
+  ];
+in {
+  inherit
+    attest
+    attest-staging
+    attest-testing
+    sgx-equinix-demo
+    snp-equinix-demo
+    store
+    store-staging
+    store-testing
+    ;
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,0 +1,6 @@
+inputs @ {nixlib, ...}: rec {
+  service = import ./service.nix inputs;
+  tooling = import ./tooling.nix inputs;
+
+  default = nixlib.lib.composeExtensions service tooling;
+}

--- a/overlays/service.nix
+++ b/overlays/service.nix
@@ -1,0 +1,35 @@
+{
+  benefice-staging,
+  benefice-testing,
+  drawbridge-production,
+  drawbridge-staging,
+  drawbridge-testing,
+  enarx,
+  steward-production,
+  steward-staging,
+  steward-testing,
+  ...
+}: final: prev: let
+  fromInput = name: src:
+    final.stdenv.mkDerivation {
+      inherit name;
+      dontUnpack = true;
+      installPhase = ''
+        mkdir -p $out/bin
+        install ${src} $out/bin/${name}
+      '';
+    };
+in {
+  benefice.testing = benefice-testing.packages.x86_64-linux.benefice-debug-x86_64-unknown-linux-musl;
+  benefice.staging = fromInput "benefice" benefice-staging;
+
+  drawbridge.testing = drawbridge-testing.packages.x86_64-linux.drawbridge-debug-x86_64-unknown-linux-musl;
+  drawbridge.staging = fromInput "drawbridge" drawbridge-staging;
+  drawbridge.production = fromInput "drawbridge" drawbridge-production;
+
+  enarx = fromInput "enarx" enarx;
+
+  steward.testing = steward-testing.packages.x86_64-linux.steward-x86_64-unknown-linux-musl;
+  steward.staging = fromInput "steward" steward-staging;
+  steward.production = fromInput "steward" steward-production;
+}

--- a/overlays/tooling.nix
+++ b/overlays/tooling.nix
@@ -1,0 +1,118 @@
+{...}: final: prev: let
+  host-key = let
+    grep = "${final.gnugrep}/bin/grep";
+    ssh-keyscan = "${final.openssh}/bin/ssh-keyscan";
+    ssh-to-age = "${final.ssh-to-age}/bin/ssh-to-age";
+  in
+    final.writeShellScriptBin "host-key" ''
+      set -e
+
+      ${ssh-keyscan} "''${1}" 2> /dev/null | ${grep} 'ssh-ed25519' | ${ssh-to-age}
+    '';
+
+  bootstrap-ca = let
+    key = ''"ca/''${1}/ca.key"'';
+    crt = ''"ca/''${1}/ca.crt"'';
+    conf = final.writeText "ca.conf" ''
+      [req]
+      distinguished_name = req_distinguished_name
+      prompt = no
+      x509_extensions = v3_ca
+
+      [req_distinguished_name]
+      C   = US
+      ST  = North Carolina
+      L   = Raleigh
+      CN  = Proof of Concept
+
+      [v3_ca]
+      basicConstraints = critical,CA:TRUE
+      keyUsage = cRLSign, keyCertSign
+      nsComment = "Profian CA certificate"
+      subjectKeyIdentifier = hash
+    '';
+
+    openssl = "${final.openssl}/bin/openssl";
+    sops = "${final.sops}/bin/sops";
+  in
+    final.writeShellScriptBin "bootstrap-ca" ''
+      set -xe
+
+      umask 0077
+
+      ${openssl} ecparam -genkey -name prime256v1 | ${openssl} pkcs8 -topk8 -nocrypt -out ${key}
+      ${openssl} req -new -x509 -days 365 -config ${conf} -key ${key} -out ${crt}
+      ${sops} -e -i ${key}
+    '';
+
+  bootstrap-steward = let
+    ca.key = ''"ca/''${1}/ca.key"'';
+    ca.crt = ''"ca/''${1}/ca.crt"'';
+
+    steward.key = ''"hosts/attest.''${1}/steward.key"'';
+    steward.csr = ''"hosts/attest.''${1}/steward.csr"'';
+    steward.crt = ''"hosts/attest.''${1}/steward.crt"'';
+
+    conf = final.writeText "steward.conf" ''
+      [req]
+      distinguished_name = req_distinguished_name
+      prompt = no
+      x509_extensions = v3_ca
+
+      [req_distinguished_name]
+      C   = US
+      ST  = North Carolina
+      L   = Raleigh
+      CN  = Proof of Concept
+
+      [v3_ca]
+      basicConstraints = critical,CA:TRUE
+      keyUsage = cRLSign, keyCertSign
+      nsComment = "Profian attestation service CA certificate"
+      subjectKeyIdentifier = hash
+    '';
+
+    openssl = "${final.openssl}/bin/openssl";
+    sops = "${final.sops}/bin/sops";
+
+    sign-cert = "${final.writeShellScriptBin "sign-cert" ''
+      set -xe
+
+      ${openssl} x509 -req -days 365 -CAcreateserial -CA ${ca.crt} -CAkey "''${2}" -in ${steward.csr} -out ${steward.crt} -extfile ${conf} -extensions v3_ca
+    ''}/bin/sign-cert";
+  in
+    final.writeShellScriptBin "bootstrap-steward" ''
+      set -xe
+
+      umask 0077
+
+      ${openssl} ecparam -genkey -name prime256v1 | ${openssl} pkcs8 -topk8 -nocrypt -out ${steward.key}
+      ${openssl} req -new -config ${conf} -key ${steward.key} -out ${steward.csr}
+      ${sops} -e -i ${steward.key}
+
+      ${sops} exec-file ${ca.key} "${sign-cert} \"''${1}\" {}"
+    '';
+
+  bootstrap = let
+    bootstrap-ca = "${final.bootstrap-ca}/bin/bootstrap-ca";
+    bootstrap-steward = "${final.bootstrap-steward}/bin/bootstrap-steward";
+  in
+    final.writeShellScriptBin "bootstrap" ''
+      set -e
+
+      for host in ca/*; do
+          ${bootstrap-ca} "''${host#'ca/'}"
+      done
+
+      for host in hosts/attest.*; do
+          ${bootstrap-steward} "''${host#'hosts/attest.'}"
+      done
+    '';
+in {
+  inherit
+    bootstrap
+    bootstrap-ca
+    bootstrap-steward
+    host-key
+    ;
+}


### PR DESCRIPTION
The top-level `flake.nix` grew quite big and became difficult to
maintain. As the functionality is mostly stable now, split into separate
components.