### PR TITLE
feat: add various images

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,12 +54,45 @@
 
           is64BitLinux = system == x86_64-linux || system == aarch64-linux;
 
-          packages = pkgs.lib.optionalAttrs is64BitLinux {
-            inherit
-              (pkgs)
-              enarx-sev-amazon
-              ;
-          };
+          packages =
+            pkgs.lib.optionalAttrs is64BitLinux {
+              inherit
+                (pkgs)
+                enarx-sev-amazon
+                enarx-sev-docker
+                enarx-sev-hyperv
+                enarx-sev-gce
+                enarx-sev-kubevirt
+                enarx-sev-lxc
+                enarx-sev-lxc-metadata
+                enarx-sev-openstack
+                enarx-sev-proxmox
+                enarx-sev-proxmox-lxc
+                enarx-sev-qcow2
+                ;
+            }
+            // pkgs.lib.optionalAttrs (system == x86_64-linux) {
+              inherit
+                (pkgs)
+                enarx-sev-azure
+                enarx-sev-install-iso
+                enarx-sev-install-iso-hyperv
+                enarx-sgx-amazon
+                enarx-sgx-azure
+                enarx-sgx-docker
+                enarx-sgx-gce
+                enarx-sgx-hyperv
+                enarx-sgx-install-iso
+                enarx-sgx-install-iso-hyperv
+                enarx-sgx-kubevirt
+                enarx-sgx-lxc
+                enarx-sgx-lxc-metadata
+                enarx-sgx-openstack
+                enarx-sgx-proxmox
+                enarx-sgx-proxmox-lxc
+                enarx-sgx-qcow2
+                ;
+            };
 
           devShell = pkgs.mkShell {
             buildInputs = with pkgs; [

--- a/overlays/images.nix
+++ b/overlays/images.nix
@@ -3,6 +3,22 @@ inputs @ {
   nixos-generators,
   ...
 }: final: prev: let
+  amazonModule = {
+    amazonImage.sizeMB = 12 * 1024; # TODO: Figure out how much we actually need
+
+    ec2.ena = false;
+  };
+
+  dockerModule = {lib, ...}: {
+    networking.firewall.enable = lib.mkForce false;
+
+    services.openssh.startWhenNeeded = lib.mkForce false;
+  };
+
+  isoModule = {lib, ...}: {
+    boot.supportedFilesystems = lib.mkForce ["btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs"];
+  };
+
   mkEnarxImage = format: modules:
     nixos-generators.nixosGenerate {
       inherit format;
@@ -44,17 +60,86 @@ inputs @ {
       ]
       ++ modules);
 
-  enarx-sev-amazon = final.mkEnarxSevImage "amazon" [
-    {
-      amazonImage.sizeMB = 12 * 1024; # TODO: Figure out how much we actually need
+  enarx-sev-amazon = final.mkEnarxSevImage "amazon" [amazonModule];
+  enarx-sev-azure = final.mkEnarxSevImage "azure" [];
+  enarx-sev-docker = final.mkEnarxSevImage "docker" [dockerModule];
+  enarx-sev-gce = final.mkEnarxSevImage "gce" [];
+  enarx-sev-hyperv = final.mkEnarxSevImage "hyperv" [];
+  enarx-sev-install-iso = final.mkEnarxSevImage "install-iso" [isoModule];
+  enarx-sev-install-iso-hyperv = final.mkEnarxSevImage "install-iso-hyperv" [isoModule];
+  enarx-sev-kubevirt = final.mkEnarxSevImage "kubevirt" [];
+  enarx-sev-lxc = final.mkEnarxSevImage "lxc" [];
+  enarx-sev-lxc-metadata = final.mkEnarxSevImage "lxc-metadata" [];
+  enarx-sev-openstack = final.mkEnarxSevImage "openstack" [];
+  enarx-sev-proxmox = final.mkEnarxSevImage "proxmox" [];
+  enarx-sev-proxmox-lxc = final.mkEnarxSevImage "proxmox-lxc" [];
+  enarx-sev-qcow2 = final.mkEnarxSevImage "qcow" [];
 
-      ec2.ena = false;
-    }
-  ];
+  mkEnarxSgxImage = format: modules:
+    mkEnarxImage format ([
+        {
+          boot.kernelModules = [
+            "kvm-intel"
+          ];
+          boot.kernelPackages = final.linuxPackages_enarx;
+
+          hardware.cpu.intel.sgx.provision.enable = true;
+
+          hardware.cpu.intel.updateMicrocode = true;
+
+          services.aesmd.enable = true;
+
+          services.enarx.backend = "sgx";
+        }
+      ]
+      ++ modules);
+
+  enarx-sgx-amazon = final.mkEnarxSgxImage "amazon" [amazonModule];
+  enarx-sgx-azure = final.mkEnarxSgxImage "azure" [];
+  enarx-sgx-docker = final.mkEnarxSgxImage "docker" [dockerModule];
+  enarx-sgx-gce = final.mkEnarxSgxImage "gce" [];
+  enarx-sgx-hyperv = final.mkEnarxSgxImage "hyperv" [];
+  enarx-sgx-install-iso = final.mkEnarxSgxImage "install-iso" [isoModule];
+  enarx-sgx-install-iso-hyperv = final.mkEnarxSgxImage "install-iso-hyperv" [isoModule];
+  enarx-sgx-kubevirt = final.mkEnarxSgxImage "kubevirt" [];
+  enarx-sgx-lxc = final.mkEnarxSgxImage "lxc" [];
+  enarx-sgx-lxc-metadata = final.mkEnarxSgxImage "lxc-metadata" [];
+  enarx-sgx-openstack = final.mkEnarxSgxImage "openstack" [];
+  enarx-sgx-proxmox = final.mkEnarxSgxImage "proxmox" [];
+  enarx-sgx-proxmox-lxc = final.mkEnarxSgxImage "proxmox-lxc" [];
+  enarx-sgx-qcow2 = final.mkEnarxSgxImage "qcow" [];
 in {
   inherit
     mkEnarxImage
     mkEnarxSevImage
+    mkEnarxSgxImage
     enarx-sev-amazon
+    enarx-sev-azure
+    enarx-sev-docker
+    enarx-sev-gce
+    enarx-sev-hyperv
+    enarx-sev-install-iso
+    enarx-sev-install-iso-hyperv
+    enarx-sev-kubevirt
+    enarx-sev-lxc
+    enarx-sev-lxc-metadata
+    enarx-sev-openstack
+    enarx-sev-proxmox
+    enarx-sev-proxmox-lxc
+    enarx-sev-qcow2
+    enarx-sgx-amazon
+    enarx-sgx-azure
+    enarx-sgx-docker
+    enarx-sgx-gce
+    enarx-sgx-hyperv
+    enarx-sgx-install-iso
+    enarx-sgx-install-iso-hyperv
+    enarx-sgx-kubevirt
+    enarx-sgx-lxc
+    enarx-sgx-lxc-metadata
+    enarx-sgx-openstack
+    enarx-sgx-proxmox
+    enarx-sgx-proxmox-lxc
+    enarx-sgx-qcow2
     ;
 }

--- a/overlays/images.nix
+++ b/overlays/images.nix
@@ -11,12 +11,15 @@ inputs @ {
         [
           "${self}/modules/common.nix"
           ({pkgs, ...}: {
+            environment.systemPackages = with pkgs; [enarx];
+
             networking.firewall.allowedTCPPorts = [
               80
               443
             ];
 
             nixpkgs.overlays = [self.overlays.service];
+
             services.enarx.enable = true;
           })
         ]


### PR DESCRIPTION
Example usage:
```
$ nix build .#enarx-sgx-install-iso
```

```
├───checks
│   ├───aarch64-darwin
│   │   ├───activate: derivation 'deploy-rs-check-activate'
│   │   └───schema: derivation 'jsonschema-deploy-system'
│   ├───aarch64-linux
│   │   ├───activate: derivation 'deploy-rs-check-activate'
│   │   └───schema: derivation 'jsonschema-deploy-system'
│   ├───i686-linux
│   │   ├───activate: derivation 'deploy-rs-check-activate'
│   │   └───schema: derivation 'jsonschema-deploy-system'
│   ├───x86_64-darwin
│   │   ├───activate: derivation 'deploy-rs-check-activate'
│   │   └───schema: derivation 'jsonschema-deploy-system'
│   └───x86_64-linux
│       ├───activate: derivation 'deploy-rs-check-activate'
│       └───schema: derivation 'jsonschema-deploy-system'
├───deploy: unknown
├───devShells
│   ├───aarch64-darwin
│   │   └───default: development environment 'nix-shell'
│   ├───aarch64-linux
│   │   └───default: development environment 'nix-shell'
│   ├───i686-linux
│   │   └───default: development environment 'nix-shell'
│   ├───x86_64-darwin
│   │   └───default: development environment 'nix-shell'
│   └───x86_64-linux
│       └───default: development environment 'nix-shell'
├───formatter
│   ├───aarch64-darwin: package 'alejandra-1.4.0'
│   ├───aarch64-linux: package 'alejandra-1.4.0'
│   ├───i686-linux: package 'alejandra-1.4.0'
│   ├───x86_64-darwin: package 'alejandra-1.4.0'
│   └───x86_64-linux: package 'alejandra-1.4.0'
├───nixosConfigurations
│   ├───attest: NixOS configuration
│   ├───attest-staging: NixOS configuration
│   ├───attest-testing: NixOS configuration
│   ├───sgx-equinix-try: NixOS configuration
│   ├───snp-equinix-try: NixOS configuration
│   ├───store: NixOS configuration
│   ├───store-staging: NixOS configuration
│   └───store-testing: NixOS configuration
├───overlays
│   ├───default: Nixpkgs overlay
│   ├───images: Nixpkgs overlay
│   ├───service: Nixpkgs overlay
│   └───tooling: Nixpkgs overlay
└───packages
    ├───aarch64-darwin
    ├───aarch64-linux
    │   ├───enarx-sev-amazon: package 'nixos-amazon-image-22.05.20220722.a231268-aarch64-linux'
    │   ├───enarx-sev-docker: package 'tarball'
    │   ├───enarx-sev-gce: package 'google-compute-image'
    │   ├───enarx-sev-hyperv: package 'nixos-hyperv-22.05.20220722.a231268-aarch64-linux'
    │   ├───enarx-sev-kubevirt: package 'nixos-disk-image'
    │   ├───enarx-sev-lxc: package 'tarball'
    │   ├───enarx-sev-lxc-metadata: package 'tarball'
    │   ├───enarx-sev-openstack: package 'nixos-disk-image'
    │   ├───enarx-sev-proxmox: package 'proxmox-nixos-22.05.20220722.a231268'
    │   ├───enarx-sev-proxmox-lxc: package 'tarball'
    │   └───enarx-sev-qcow2: package 'nixos-disk-image'
    ├───i686-linux
    ├───x86_64-darwin
    └───x86_64-linux
        ├───enarx-sev-amazon: package 'nixos-amazon-image-22.05.20220722.a231268-x86_64-linux'
        ├───enarx-sev-azure: package 'azure-image'
        ├───enarx-sev-docker: package 'tarball'
        ├───enarx-sev-gce: package 'google-compute-image'
        ├───enarx-sev-hyperv: package 'nixos-hyperv-22.05.20220722.a231268-x86_64-linux'
        ├───enarx-sev-install-iso: package 'nixos-22.05.20220722.a231268-x86_64-linux.isonixos.iso'
        ├───enarx-sev-install-iso-hyperv: package 'nixos-22.05.20220722.a231268-x86_64-linux.iso'
        ├───enarx-sev-kubevirt: package 'nixos-disk-image'
        ├───enarx-sev-lxc: package 'tarball'
        ├───enarx-sev-lxc-metadata: package 'tarball'
        ├───enarx-sev-openstack: package 'nixos-disk-image'
        ├───enarx-sev-proxmox: package 'proxmox-nixos-22.05.20220722.a231268'
        ├───enarx-sev-proxmox-lxc: package 'tarball'
        ├───enarx-sev-qcow2: package 'nixos-disk-image'
        ├───enarx-sgx-amazon: package 'nixos-amazon-image-22.05.20220722.a231268-x86_64-linux'
        ├───enarx-sgx-azure: package 'azure-image'
        ├───enarx-sgx-docker: package 'tarball'
        ├───enarx-sgx-gce: package 'google-compute-image'
        ├───enarx-sgx-hyperv: package 'nixos-hyperv-22.05.20220722.a231268-x86_64-linux'
        ├───enarx-sgx-install-iso: package 'nixos-22.05.20220722.a231268-x86_64-linux.isonixos.iso'
        ├───enarx-sgx-install-iso-hyperv: package 'nixos-22.05.20220722.a231268-x86_64-linux.iso'
        ├───enarx-sgx-kubevirt: package 'nixos-disk-image'
        ├───enarx-sgx-lxc: package 'tarball'
        ├───enarx-sgx-lxc-metadata: package 'tarball'
        ├───enarx-sgx-openstack: package 'nixos-disk-image'
        ├───enarx-sgx-proxmox: package 'proxmox-nixos-22.05.20220722.a231268'
        ├───enarx-sgx-proxmox-lxc: package 'tarball'
        └───enarx-sgx-qcow2: package 'nixos-disk-image'
```