### PR TITLE
build: switch to enarx fork

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -171,13 +171,13 @@
     "enarx": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-bIGs0FbLVAfQoJRXHOCPG0tZ+OJy/nb/rBBMJ7ja2xg=",
+        "narHash": "sha256-G6l77Szld7serZfuqQPryl0DTx8R09rC4qP/3XEJ5JI=",
         "type": "file",
-        "url": "https://github.com/enarx/enarx/releases/download/v0.6.2/enarx-x86_64-unknown-linux-musl"
+        "url": "https://github.com/rvolosatovs/enarx/releases/download/v0.6.3-rc1/enarx-x86_64-unknown-linux-musl"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/enarx/enarx/releases/download/v0.6.2/enarx-x86_64-unknown-linux-musl"
+        "url": "https://github.com/rvolosatovs/enarx/releases/download/v0.6.3-rc1/enarx-x86_64-unknown-linux-musl"
       }
     },
     "fenix": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
   inputs.drawbridge-staging.url = "https://github.com/profianinc/drawbridge/releases/download/v0.2.0/drawbridge-x86_64-unknown-linux-musl";
   inputs.drawbridge-testing.url = github:profianinc/drawbridge;
   inputs.enarx.flake = false;
-  inputs.enarx.url = "https://github.com/enarx/enarx/releases/download/v0.6.2/enarx-x86_64-unknown-linux-musl";
+  inputs.enarx.url = "https://github.com/rvolosatovs/enarx/releases/download/v0.6.3-rc1/enarx-x86_64-unknown-linux-musl";
   inputs.flake-compat.flake = false;
   inputs.flake-compat.url = github:edolstra/flake-compat;
   inputs.flake-utils.url = github:numtide/flake-utils;


### PR DESCRIPTION
Temporarily, until https://github.com/enarx/enarx/pull/2107 ends up in a release