### PR TITLE
feat: automatic staging deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,28 @@ jobs:
       with:
         name: enarx
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: Deploy
-      # TODO: Reenable https://github.com/profianinc/infrastructure/issues/1
+    - name: Setup SSH
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       run: |
-        nix develop -c deploy || exit 0
+        umask 0077
+        mkdir -p ~/.ssh
+        printf '%s' '${{ secrets.SSH_KEY }}' > ~/.ssh/id_ed25519
+        chmod 400 ~/.ssh/id_ed25519
+        ssh-agent -a $SSH_AUTH_SOCK
+        ssh-add ~/.ssh/id_ed25519
+        ssh-keyscan attest.staging.profian.com >> ~/.ssh/known_hosts
+        ssh-keyscan attest.testing.profian.com >> ~/.ssh/known_hosts
+        ssh-keyscan benefice.testing.profian.com >> ~/.ssh/known_hosts
+        ssh-keyscan store.staging.profian.com >> ~/.ssh/known_hosts
+        ssh-keyscan store.testing.profian.com >> ~/.ssh/known_hosts
+    - name: Deploy
+      env:
+        SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+      run: |
+        nix develop '.#base' -c deploy -s --targets \
+          '.#attest-staging' \
+          '.#attest-testing' \
+          '.#benefice-testing' \
+          '.#store-staging' \
+          '.#store-testing'

--- a/flake.nix
+++ b/flake.nix
@@ -42,28 +42,36 @@
           overlays = [self.overlays.default];
         };
 
-        devShell = pkgs.mkShell {
+        devShells.base = pkgs.mkShell {
           buildInputs = with pkgs; [
-            age
-            awscli2
             nixUnstable
             openssh
-            openssl
-            sops
-            ssh-to-age
-            tailscale
-
-            bootstrap
-            bootstrap-ca
-            bootstrap-steward
-            host-key
-            ssh-for-each
 
             deploy-rs.packages.${system}.default
           ];
         };
+
+        devShells.default = devShells.base.overrideAttrs (attrs: {
+          buildInputs = with pkgs;
+            attrs.buildInputs
+            ++ [
+              age
+              awscli2
+              openssl
+              sops
+              ssh-to-age
+              tailscale
+
+              bootstrap
+              bootstrap-ca
+              bootstrap-steward
+              host-key
+              ssh-for-each
+            ];
+        });
       in {
-        devShells.default = devShell;
+        inherit devShells;
+
         formatter = pkgs.alejandra;
       }
     );

--- a/nixosConfigurations/services/benefice.nix
+++ b/nixosConfigurations/services/benefice.nix
@@ -46,6 +46,7 @@ with flake-utils.lib.system; let
     ({pkgs, ...}: {
       imports = [
         "${self}/hosts/benefice.testing.profian.com"
+        "${self}/nixosModules/ci.nix"
       ];
 
       services.benefice.log.level = "debug";

--- a/nixosConfigurations/services/benefice.nix
+++ b/nixosConfigurations/services/benefice.nix
@@ -32,6 +32,13 @@ with flake-utils.lib.system; let
       sops.secrets.oidc-secret.sopsFile = "${self}/hosts/${config.networking.fqdn}/oidc-secret";
 
       systemd.services.benefice = self.lib.systemd.withSecret config pkgs "benefice" "oidc-secret";
+
+      # Workaround for https://github.com/profianinc/infrastructure/issues/109
+
+      users.groups.benefice = {};
+
+      users.users.benefice.isSystemUser = true;
+      users.users.benefice.group = config.users.groups.benefice.name;
     })
   ];
 

--- a/nixosConfigurations/services/benefice.nix
+++ b/nixosConfigurations/services/benefice.nix
@@ -76,19 +76,6 @@ with flake-utils.lib.system; let
       services.benefice.log.level = "info";
       services.benefice.oidc.client = "Ayrct2YbMF6OHFN8bzpv3XemWI3ca5Hk";
       services.benefice.package = pkgs.benefice.staging;
-
-      systemd.services.snp-modprobe.restartIfChanged = false;
-      systemd.services.snp-modprobe.script = with pkgs; ''
-        ${kmod}/bin/modprobe ccp
-        ${kmod}/bin/modprobe kvm_amd
-        ${kmod}/bin/modprobe -r kvm_amd
-        ${kmod}/bin/modprobe -r ccp
-        ${kmod}/bin/modprobe ccp
-        ${kmod}/bin/modprobe kvm_amd
-        ${enarx}/bin/enarx platform snp update
-      '';
-      systemd.services.snp-modprobe.serviceConfig.Type = "oneshot";
-      systemd.services.snp-modprobe.wantedBy = ["multi-user.target"];
     })
   ];
 in {

--- a/nixosConfigurations/services/drawbridge.nix
+++ b/nixosConfigurations/services/drawbridge.nix
@@ -21,6 +21,7 @@ with flake-utils.lib.system; let
     ({pkgs, ...}: {
       imports = [
         "${self}/hosts/store.testing.profian.com"
+        "${self}/nixosModules/ci.nix"
       ];
 
       services.drawbridge.log.level = "debug";
@@ -33,6 +34,7 @@ with flake-utils.lib.system; let
     ({pkgs, ...}: {
       imports = [
         "${self}/hosts/store.staging.profian.com"
+        "${self}/nixosModules/ci.nix"
       ];
 
       services.drawbridge.log.level = "info";

--- a/nixosConfigurations/services/steward.nix
+++ b/nixosConfigurations/services/steward.nix
@@ -23,6 +23,13 @@ with flake-utils.lib.system; let
       sops.secrets.key.sopsFile = "${self}/hosts/${config.networking.fqdn}/steward.key";
 
       systemd.services.steward = self.lib.systemd.withSecret config pkgs "steward" "key";
+
+      # Workaround for https://github.com/profianinc/infrastructure/issues/109
+
+      users.groups.steward = {};
+
+      users.users.steward.isSystemUser = true;
+      users.users.steward.group = config.users.groups.steward.name;
     })
   ];
 

--- a/nixosConfigurations/services/steward.nix
+++ b/nixosConfigurations/services/steward.nix
@@ -37,6 +37,7 @@ with flake-utils.lib.system; let
     ({pkgs, ...}: {
       imports = [
         "${self}/hosts/attest.testing.profian.com"
+        "${self}/nixosModules/ci.nix"
       ];
 
       services.steward.log.level = "debug";
@@ -48,6 +49,7 @@ with flake-utils.lib.system; let
     ({pkgs, ...}: {
       imports = [
         "${self}/hosts/attest.staging.profian.com"
+        "${self}/nixosModules/ci.nix"
       ];
 
       services.steward.log.level = "info";

--- a/nixosModules/ci.nix
+++ b/nixosModules/ci.nix
@@ -1,0 +1,8 @@
+# TODO: This should be merged with users.nix into a configurable NixOS module
+{...}: let
+  keys.ci = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBP5eXj567djd1G54kmt1U00gsFVOex0qNldmeRAHCol";
+in {
+  users.users.deploy.openssh.authorizedKeys.keys = with keys; [
+    ci
+  ];
+}

--- a/nixosModules/common.nix
+++ b/nixosModules/common.nix
@@ -83,7 +83,10 @@ in {
 
   services.openssh.enable = true;
   services.openssh.passwordAuthentication = false;
+  services.openssh.permitRootLogin = lib.mkForce "no";
   services.openssh.startWhenNeeded = true;
 
   system.stateVersion = "22.05";
+
+  users.users.root.hashedPassword = "!"; # nothing hashes to `!`, so this disables root logins
 }

--- a/nixosModules/users.nix
+++ b/nixosModules/users.nix
@@ -60,8 +60,6 @@ in {
     }
   ];
 
-  services.openssh.permitRootLogin = lib.mkForce "no";
-
   users.groups.deploy = {};
   users.groups.ops = {};
 
@@ -95,8 +93,6 @@ in {
   users.users.puiterwijk.extraGroups = adminGroups;
   users.users.puiterwijk.openssh.authorizedKeys.keys = with keys; [puiterwijk];
   users.users.puiterwijk.shell = pkgs.bashInteractive;
-
-  users.users.root.hashedPassword = "!"; # nothing hashes to `!`, so this disables root logins
 
   users.users.rvolosatovs.isNormalUser = true;
   users.users.rvolosatovs.extraGroups = adminGroups;


### PR DESCRIPTION
- Add a workaround for #109
- Remove `snp-modprobe` workaround since most recent Enarx kernel is used
- Add private SSH key to CI with access to `deploy` user