### PR TITLE
feat: allow multiple hosts per service

### DIFF
--- a/hosts/attest.profian.com/default.nix
+++ b/hosts/attest.profian.com/default.nix
@@ -4,7 +4,4 @@
   ];
 
   ec2.hvm = true;
-
-  networking.domain = "profian.com";
-  networking.hostName = "attest";
 }

--- a/hosts/attest.staging.profian.com/default.nix
+++ b/hosts/attest.staging.profian.com/default.nix
@@ -4,7 +4,4 @@
   ];
 
   ec2.hvm = true;
-
-  networking.domain = "staging.profian.com";
-  networking.hostName = "attest";
 }

--- a/hosts/attest.testing.profian.com/default.nix
+++ b/hosts/attest.testing.profian.com/default.nix
@@ -4,7 +4,4 @@
   ];
 
   ec2.hvm = true;
-
-  networking.domain = "testing.profian.com";
-  networking.hostName = "attest";
 }

--- a/hosts/benefice.testing.profian.com/default.nix
+++ b/hosts/benefice.testing.profian.com/default.nix
@@ -2,7 +2,4 @@
   imports = [
     "${modulesPath}/virtualisation/amazon-image.nix"
   ];
-
-  networking.domain = "testing.profian.com";
-  networking.hostName = "benefice";
 }

--- a/hosts/nuc-1.infra.profian.com/default.nix
+++ b/hosts/nuc-1.infra.profian.com/default.nix
@@ -31,8 +31,6 @@
 
   hardware.cpu.intel.updateMicrocode = true;
 
-  networking.domain = "infra.profian.com";
-  networking.hostName = "nuc-1";
   networking.useDHCP = true;
 
   powerManagement.cpuFreqGovernor = "powersave";

--- a/hosts/sgx.equinix.try.enarx.dev/default.nix
+++ b/hosts/sgx.equinix.try.enarx.dev/default.nix
@@ -23,9 +23,7 @@ in {
   hardware.cpu.intel.sgx.provision.enable = true;
   hardware.cpu.intel.updateMicrocode = true;
 
-  networking.domain = "equinix.try.enarx.dev";
   networking.hostId = "395c78d1";
-  networking.hostName = "sgx";
   networking.interfaces.eno12399.useDHCP = true;
   networking.interfaces.eno12409.useDHCP = true;
   networking.interfaces.eno12419.useDHCP = true;

--- a/hosts/snp.equinix.try.enarx.dev/default.nix
+++ b/hosts/snp.equinix.try.enarx.dev/default.nix
@@ -28,9 +28,7 @@
 
   hardware.cpu.amd.updateMicrocode = true;
 
-  networking.domain = "equinix.try.enarx.dev";
   networking.hostId = "4a7d85ee";
-  networking.hostName = "snp";
   networking.interfaces.enp65s0f0.useDHCP = true;
   networking.interfaces.enp65s0f1.useDHCP = true;
 

--- a/hosts/store.profian.com/default.nix
+++ b/hosts/store.profian.com/default.nix
@@ -4,7 +4,4 @@
   ];
 
   ec2.hvm = true;
-
-  networking.domain = "profian.com";
-  networking.hostName = "store";
 }

--- a/hosts/store.staging.profian.com/default.nix
+++ b/hosts/store.staging.profian.com/default.nix
@@ -4,7 +4,4 @@
   ];
 
   ec2.hvm = true;
-
-  networking.domain = "staging.profian.com";
-  networking.hostName = "store";
 }

--- a/hosts/store.testing.profian.com/default.nix
+++ b/hosts/store.testing.profian.com/default.nix
@@ -4,7 +4,4 @@
   ];
 
   ec2.hvm = true;
-
-  networking.domain = "testing.profian.com";
-  networking.hostName = "store";
 }

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -3,7 +3,7 @@
   nixpkgs,
   ...
 }: rec {
-  mkHost = base: system: extraModules: hostname:
+  mkHost = base: system: extraModules: domain: hostName:
     nixpkgs.lib.nixosSystem {
       inherit system;
 
@@ -16,8 +16,11 @@
         ++ extraModules
         ++ [
           ({...}: {
+            networking.hostName = hostName;
+            networking.domain = domain;
+
             imports = [
-              "${self}/hosts/${hostname}"
+              "${self}/hosts/${hostName}.${domain}"
             ];
           })
         ];

--- a/lib/hosts.nix
+++ b/lib/hosts.nix
@@ -3,7 +3,7 @@
   nixpkgs,
   ...
 }: rec {
-  mkHost = base: system: extraModules:
+  mkHost = base: system: extraModules: hostname:
     nixpkgs.lib.nixosSystem {
       inherit system;
 
@@ -13,7 +13,14 @@
           self.nixosModules.users
         ]
         ++ base
-        ++ extraModules;
+        ++ extraModules
+        ++ [
+          ({...}: {
+            imports = [
+              "${self}/hosts/${hostname}"
+            ];
+          })
+        ];
     };
 
   mkService = base:

--- a/nixosConfigurations/infra.nix
+++ b/nixosConfigurations/infra.nix
@@ -25,7 +25,7 @@ with flake-utils.lib.system; let
   nuc-1 = mkInfra x86_64-linux [
     ({...}: {
     })
-  ] "nuc-1.infra.profian.com";
+  ] "infra.profian.com" "nuc-1";
 in {
   inherit
     nuc-1

--- a/nixosConfigurations/infra.nix
+++ b/nixosConfigurations/infra.nix
@@ -24,11 +24,8 @@ with flake-utils.lib.system; let
 
   nuc-1 = mkInfra x86_64-linux [
     ({...}: {
-      imports = [
-        "${self}/hosts/nuc-1.infra.profian.com"
-      ];
     })
-  ];
+  ] "nuc-1.infra.profian.com";
 in {
   inherit
     nuc-1

--- a/nixosConfigurations/services/benefice.nix
+++ b/nixosConfigurations/services/benefice.nix
@@ -71,7 +71,6 @@ with flake-utils.lib.system; let
   benefice-testing = mkBenefice x86_64-linux [
     ({pkgs, ...}: {
       imports = [
-        "${self}/hosts/benefice.testing.profian.com"
         "${self}/nixosModules/ci.nix"
       ];
 
@@ -79,19 +78,15 @@ with flake-utils.lib.system; let
       services.benefice.oidc.client = "FTmeUMamlu8HRs11mvtmmZHnmCwRIo8E";
       services.benefice.package = pkgs.benefice.testing;
     })
-  ];
+  ] "benefice.testing.profian.com";
 
   sgx-equinix-try = mkBenefice x86_64-linux [
     ({pkgs, ...}: {
-      imports = [
-        "${self}/hosts/sgx.equinix.try.enarx.dev"
-      ];
-
       services.benefice.log.level = "info";
       services.benefice.oidc.client = "23Lt09AjF8HpUeCCwlfhuV34e2dKD1MH";
       services.benefice.package = pkgs.benefice.staging;
     })
-  ];
+  ] "sgx.equinix.try.enarx.dev";
 
   snp-equinix-try = mkBenefice x86_64-linux [
     ({pkgs, ...}: {
@@ -103,7 +98,7 @@ with flake-utils.lib.system; let
       services.benefice.oidc.client = "Ayrct2YbMF6OHFN8bzpv3XemWI3ca5Hk";
       services.benefice.package = pkgs.benefice.staging;
     })
-  ];
+  ] "snp.equinix.try.enarx.dev";
 in {
   inherit
     benefice-testing

--- a/nixosConfigurations/services/benefice.nix
+++ b/nixosConfigurations/services/benefice.nix
@@ -78,7 +78,7 @@ with flake-utils.lib.system; let
       services.benefice.oidc.client = "FTmeUMamlu8HRs11mvtmmZHnmCwRIo8E";
       services.benefice.package = pkgs.benefice.testing;
     })
-  ] "benefice.testing.profian.com";
+  ] "testing.profian.com" "benefice";
 
   sgx-equinix-try = mkBenefice x86_64-linux [
     ({pkgs, ...}: {
@@ -86,7 +86,7 @@ with flake-utils.lib.system; let
       services.benefice.oidc.client = "23Lt09AjF8HpUeCCwlfhuV34e2dKD1MH";
       services.benefice.package = pkgs.benefice.staging;
     })
-  ] "sgx.equinix.try.enarx.dev";
+  ] "equinix.try.enarx.dev" "sgx";
 
   snp-equinix-try = mkBenefice x86_64-linux [
     ({pkgs, ...}: {
@@ -98,7 +98,7 @@ with flake-utils.lib.system; let
       services.benefice.oidc.client = "Ayrct2YbMF6OHFN8bzpv3XemWI3ca5Hk";
       services.benefice.package = pkgs.benefice.staging;
     })
-  ] "snp.equinix.try.enarx.dev";
+  ] "equinix.try.enarx.dev" "snp";
 in {
   inherit
     benefice-testing

--- a/nixosConfigurations/services/drawbridge.nix
+++ b/nixosConfigurations/services/drawbridge.nix
@@ -20,7 +20,6 @@ with flake-utils.lib.system; let
   store-testing = mkDrawbridge x86_64-linux [
     ({pkgs, ...}: {
       imports = [
-        "${self}/hosts/store.testing.profian.com"
         "${self}/nixosModules/ci.nix"
       ];
 
@@ -28,12 +27,11 @@ with flake-utils.lib.system; let
       services.drawbridge.oidc.client = "zFrR7MKMakS4OpEflR0kNw3ceoP7sr3s";
       services.drawbridge.package = pkgs.drawbridge.testing;
     })
-  ];
+  ] "store.testing.profian.com";
 
   store-staging = mkDrawbridge x86_64-linux [
     ({pkgs, ...}: {
       imports = [
-        "${self}/hosts/store.staging.profian.com"
         "${self}/nixosModules/ci.nix"
       ];
 
@@ -41,18 +39,14 @@ with flake-utils.lib.system; let
       services.drawbridge.oidc.client = "9SVWiB3sQQdzKqpZmMNvsb9rzd8Ha21F";
       services.drawbridge.package = pkgs.drawbridge.staging;
     })
-  ];
+  ] "store.staging.profian.com";
 
   store = mkDrawbridge x86_64-linux [
     ({pkgs, ...}: {
-      imports = [
-        "${self}/hosts/store.profian.com"
-      ];
-
       services.drawbridge.oidc.client = "2vq9XnQgcGZ9JCxsGERuGURYIld3mcIh";
       services.drawbridge.package = pkgs.drawbridge.production;
     })
-  ];
+  ] "store.profian.com";
 in {
   inherit
     store

--- a/nixosConfigurations/services/drawbridge.nix
+++ b/nixosConfigurations/services/drawbridge.nix
@@ -27,7 +27,7 @@ with flake-utils.lib.system; let
       services.drawbridge.oidc.client = "zFrR7MKMakS4OpEflR0kNw3ceoP7sr3s";
       services.drawbridge.package = pkgs.drawbridge.testing;
     })
-  ] "store.testing.profian.com";
+  ] "testing.profian.com" "store";
 
   store-staging = mkDrawbridge x86_64-linux [
     ({pkgs, ...}: {
@@ -39,14 +39,14 @@ with flake-utils.lib.system; let
       services.drawbridge.oidc.client = "9SVWiB3sQQdzKqpZmMNvsb9rzd8Ha21F";
       services.drawbridge.package = pkgs.drawbridge.staging;
     })
-  ] "store.staging.profian.com";
+  ] "staging.profian.com" "store";
 
   store = mkDrawbridge x86_64-linux [
     ({pkgs, ...}: {
       services.drawbridge.oidc.client = "2vq9XnQgcGZ9JCxsGERuGURYIld3mcIh";
       services.drawbridge.package = pkgs.drawbridge.production;
     })
-  ] "store.profian.com";
+  ] "profian.com" "store";
 in {
   inherit
     store

--- a/nixosConfigurations/services/steward.nix
+++ b/nixosConfigurations/services/steward.nix
@@ -36,36 +36,30 @@ with flake-utils.lib.system; let
   attest-testing = mkSteward x86_64-linux [
     ({pkgs, ...}: {
       imports = [
-        "${self}/hosts/attest.testing.profian.com"
         "${self}/nixosModules/ci.nix"
       ];
 
       services.steward.log.level = "debug";
       services.steward.package = pkgs.steward.testing;
     })
-  ];
+  ] "attest.testing.profian.com";
 
   attest-staging = mkSteward x86_64-linux [
     ({pkgs, ...}: {
       imports = [
-        "${self}/hosts/attest.staging.profian.com"
         "${self}/nixosModules/ci.nix"
       ];
 
       services.steward.log.level = "info";
       services.steward.package = pkgs.steward.staging;
     })
-  ];
+  ] "attest.staging.profian.com";
 
   attest = mkSteward x86_64-linux [
-    ({pkgs, ...}: {
-      imports = [
-        "${self}/hosts/attest.profian.com"
-      ];
-
+    ({config, pkgs, ...}: {
       services.steward.package = pkgs.steward.production;
     })
-  ];
+  ] "attest.profian.com";
 in {
   inherit
     attest

--- a/nixosConfigurations/services/steward.nix
+++ b/nixosConfigurations/services/steward.nix
@@ -42,7 +42,7 @@ with flake-utils.lib.system; let
       services.steward.log.level = "debug";
       services.steward.package = pkgs.steward.testing;
     })
-  ] "attest.testing.profian.com";
+  ] "testing.profian.com" "attest";
 
   attest-staging = mkSteward x86_64-linux [
     ({pkgs, ...}: {
@@ -53,13 +53,13 @@ with flake-utils.lib.system; let
       services.steward.log.level = "info";
       services.steward.package = pkgs.steward.staging;
     })
-  ] "attest.staging.profian.com";
+  ] "staging.profian.com" "attest";
 
   attest = mkSteward x86_64-linux [
-    ({config, pkgs, ...}: {
+    ({pkgs, ...}: {
       services.steward.package = pkgs.steward.production;
     })
-  ] "attest.profian.com";
+  ] "profian.com" "attest";
 in {
   inherit
     attest


### PR DESCRIPTION
This prepares the repository for having multiple hosts to provide a
single service, by adding a "host" argument to mkHost, which then
decides which host configuration to import.
This allows e.g.:
  prod1 = mkSteward x86_64-linux [..] "prod1.attest.profian.com";
  prod1 = mkSteward x86_64_linux [..] "prod2.attest.profian.com";

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>