### PR TITLE
build: update `benefice`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -9,16 +9,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1661169406,
-        "narHash": "sha256-QK6suMpQYghQGLnAxskGXz+xxYONjYYatPohKDvWYQo=",
+        "lastModified": 1661417167,
+        "narHash": "sha256-IaIazuEQN0ZyPsLmyb7RJBsfKCxJ/YiB66VeDHsLv5I=",
         "owner": "profianinc",
         "repo": "benefice",
-        "rev": "c39043f29f5e10aff23d480e8aaa886d9be3c524",
+        "rev": "a1c4e484b6103c021ce4b679b2ea595689f2fc16",
         "type": "github"
       },
       "original": {
         "owner": "profianinc",
-        "ref": "v0.1.0-rc16",
+        "ref": "v0.1.0",
         "repo": "benefice",
         "type": "github"
       }
@@ -32,11 +32,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1661169406,
-        "narHash": "sha256-QK6suMpQYghQGLnAxskGXz+xxYONjYYatPohKDvWYQo=",
+        "lastModified": 1661417167,
+        "narHash": "sha256-IaIazuEQN0ZyPsLmyb7RJBsfKCxJ/YiB66VeDHsLv5I=",
         "owner": "profianinc",
         "repo": "benefice",
-        "rev": "c39043f29f5e10aff23d480e8aaa886d9be3c524",
+        "rev": "a1c4e484b6103c021ce4b679b2ea595689f2fc16",
         "type": "github"
       },
       "original": {
@@ -572,11 +572,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -737,11 +737,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657180868,
-        "narHash": "sha256-pRGoBUIn35fa2ptlMiJ+0Tb4GhC0SQXMQLuIhIt7SHo=",
+        "lastModified": 1661414246,
+        "narHash": "sha256-NhQIL4nI+7lI0KrooZEBuZlj0xmtF1Evhlj70vFnxro=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c82c6d29482b4e08c264288e0a4bc14d5d84e8e",
+        "rev": "c6ea2601a066e09ae862287227087d8d61412b88",
         "type": "github"
       },
       "original": {
@@ -798,11 +798,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1657180868,
-        "narHash": "sha256-pRGoBUIn35fa2ptlMiJ+0Tb4GhC0SQXMQLuIhIt7SHo=",
+        "lastModified": 1661414246,
+        "narHash": "sha256-NhQIL4nI+7lI0KrooZEBuZlj0xmtF1Evhlj70vFnxro=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c82c6d29482b4e08c264288e0a4bc14d5d84e8e",
+        "rev": "c6ea2601a066e09ae862287227087d8d61412b88",
         "type": "github"
       },
       "original": {
@@ -889,11 +889,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1661172107,
-        "narHash": "sha256-jBLTaUUK5985ZsuuwqpJMjLwxcCTx7V2aonMzWJnq9M=",
+        "lastModified": 1661382769,
+        "narHash": "sha256-aixcqqNuSh0Z7NUKn7D6BjJHKGGZGBm3I/9qPoeh4iw=",
         "owner": "profianinc",
         "repo": "nixpkgs",
-        "rev": "b2ac38de438e4a7120b4792fb91787b4c93dd391",
+        "rev": "e38d3d8bcd160e9a6e46427da037d14759b46a9a",
         "type": "github"
       },
       "original": {
@@ -1016,11 +1016,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657162416,
-        "narHash": "sha256-5HckhpteVHcb++qPFw8L9bHd/B1EAzQxDeAPXAKML70=",
+        "lastModified": 1661396338,
+        "narHash": "sha256-HeENaS1srLqjdEZP7s+UBpBQtkHC6PYx8O03TXrwIws=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b1b998b47b15bc5e18a1b364c9c4f145bb0a3931",
+        "rev": "c97cf9d581e09b767f5e3503b43dc3e4cd91bd99",
         "type": "github"
       },
       "original": {
@@ -1041,11 +1041,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1657162416,
-        "narHash": "sha256-5HckhpteVHcb++qPFw8L9bHd/B1EAzQxDeAPXAKML70=",
+        "lastModified": 1661396338,
+        "narHash": "sha256-HeENaS1srLqjdEZP7s+UBpBQtkHC6PYx8O03TXrwIws=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b1b998b47b15bc5e18a1b364c9c4f145bb0a3931",
+        "rev": "c97cf9d581e09b767f5e3503b43dc3e4cd91bd99",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Profian Inc Network Infrastructure";
 
-  inputs.benefice-staging.url = github:profianinc/benefice/v0.1.0-rc16;
+  inputs.benefice-staging.url = github:profianinc/benefice/v0.1.0;
   inputs.benefice-testing.url = github:profianinc/benefice;
   inputs.deploy-rs.inputs.flake-compat.follows = "flake-compat";
   inputs.deploy-rs.url = github:serokell/deploy-rs;


### PR DESCRIPTION
Update `benefice` and `nixpkgs` inputs (https://github.com/profianinc/nixpkgs/pull/15)

This PR is blocked on https://github.com/profianinc/benefice/pull/146

This is currently deployed to https://benefice.testing.profian.com