### PR TITLE
fix: run Benefice as root

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -888,11 +888,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1661946275,
-        "narHash": "sha256-eC8C56lbhUeRD+HsED5kpimYyeKOj7iTvVkCssYc/no=",
+        "lastModified": 1661958592,
+        "narHash": "sha256-ILB4pmyhTTN5PrbcvVjYFFRsGVb/KmrJKIHAAnlJfTI=",
         "owner": "profianinc",
         "repo": "nixpkgs",
-        "rev": "2fc08cf4dc2b5b2758b489cb1cd7d4f8254a53c7",
+        "rev": "4c897947e2d7908872796cbd435810944be38cff",
         "type": "github"
       },
       "original": {

--- a/nixosConfigurations/services/benefice.nix
+++ b/nixosConfigurations/services/benefice.nix
@@ -39,8 +39,6 @@ with flake-utils.lib.system; let
       sops.secrets.oidc-secret.restartUnits = ["benefice.service"];
       sops.secrets.oidc-secret.sopsFile = "${self}/hosts/${config.networking.fqdn}/oidc-secret";
 
-      systemd.services.benefice = self.lib.systemd.withSecret config pkgs "benefice" "oidc-secret";
-
       systemd.services.load-enarx-image.script = "${pkgs.docker}/bin/docker load < ${enarx-oci}";
       systemd.services.load-enarx-image.serviceConfig.Type = "oneshot";
       systemd.services.load-enarx-image.serviceConfig.DynamicUser = true;


### PR DESCRIPTION
This really should not be necessary, but that's the only solution that
works

This is currently deployed to all systems.