### PR TITLE
feat: remove attest.profian.com (the ec2 instance)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
         # Steward
         - nixosConfigurations.attest-staging.config.system.build.toplevel
         - nixosConfigurations.attest-testing.config.system.build.toplevel
-        - nixosConfigurations.attest.config.system.build.toplevel
 
         # Steward production
         - nixosConfigurations.attest-production-1.config.system.build.toplevel

--- a/deploy/default.nix
+++ b/deploy/default.nix
@@ -22,7 +22,6 @@ in {
   nodes.attest-production-3 = mkGenericNode self.nixosConfigurations.attest-production-3;
   nodes.attest-production-4 = mkGenericNode self.nixosConfigurations.attest-production-4;
 
-  nodes.attest = mkGenericNode self.nixosConfigurations.attest;
   nodes.attest-staging = mkGenericNode self.nixosConfigurations.attest-staging;
   nodes.attest-testing = mkGenericNode self.nixosConfigurations.attest-testing;
   nodes.benefice-testing = mkGenericNode self.nixosConfigurations.benefice-testing;

--- a/nixosConfigurations/services/steward.nix
+++ b/nixosConfigurations/services/steward.nix
@@ -99,14 +99,6 @@ with flake-utils.lib.system; let
     })
   ];
 
-  attest = mkEC2 [
-    ({...}: {
-      profian.environment = "production";
-
-      networking.domain = "profian.com";
-    })
-  ];
-
   mkProd = n:
     nixpkgs.lib.nixosSystem {
       system = x86_64-linux;
@@ -125,7 +117,6 @@ with flake-utils.lib.system; let
   attest-production-4 = mkProd 4;
 in {
   inherit
-    attest
     attest-staging
     attest-testing
     attest-production-1


### PR DESCRIPTION
This instance has been taken over by the production-{1,2,3,4} instances.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>