### PR TITLE
chore: bump benefice

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,6 @@
 {
   "nodes": {
-    "benefice-staging": {
+    "benefice-production": {
       "inputs": {
         "cargo2nix": "cargo2nix",
         "flake-compat": "flake-compat",
@@ -9,21 +9,21 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1661946091,
-        "narHash": "sha256-hCfHOdHFdt4v7YuxT385av++CDprqocoPALJIELY4ME=",
+        "lastModified": 1663149776,
+        "narHash": "sha256-VAU5szDRFWRasytO6WCaCUZ9RnW2TA8a6ib5okgudJ0=",
         "owner": "profianinc",
         "repo": "benefice",
-        "rev": "d3a46ac8fc84c16d78622050ab97e3fa5028c0f3",
+        "rev": "1cd12fdf7fefb92dfdaf4aa19a461430f1ab1061",
         "type": "github"
       },
       "original": {
         "owner": "profianinc",
-        "ref": "v0.1.1",
+        "ref": "v0.1.2-rc4",
         "repo": "benefice",
         "type": "github"
       }
     },
-    "benefice-testing": {
+    "benefice-staging": {
       "inputs": {
         "cargo2nix": "cargo2nix_2",
         "flake-compat": "flake-compat_2",
@@ -32,11 +32,34 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1662643386,
-        "narHash": "sha256-8bx+NrBJSFtpQHKY5brk2Ws92RXR1HqlJqD3ayMhavY=",
+        "lastModified": 1663149776,
+        "narHash": "sha256-VAU5szDRFWRasytO6WCaCUZ9RnW2TA8a6ib5okgudJ0=",
         "owner": "profianinc",
         "repo": "benefice",
-        "rev": "904431bf6c136ced23ebeb1810676cc0426ff435",
+        "rev": "1cd12fdf7fefb92dfdaf4aa19a461430f1ab1061",
+        "type": "github"
+      },
+      "original": {
+        "owner": "profianinc",
+        "ref": "v0.1.2-rc4",
+        "repo": "benefice",
+        "type": "github"
+      }
+    },
+    "benefice-testing": {
+      "inputs": {
+        "cargo2nix": "cargo2nix_3",
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": "nixpkgs_3",
+        "rust-overlay": "rust-overlay_3"
+      },
+      "locked": {
+        "lastModified": 1663149776,
+        "narHash": "sha256-VAU5szDRFWRasytO6WCaCUZ9RnW2TA8a6ib5okgudJ0=",
+        "owner": "profianinc",
+        "repo": "benefice",
+        "rev": "1cd12fdf7fefb92dfdaf4aa19a461430f1ab1061",
         "type": "github"
       },
       "original": {
@@ -48,19 +71,19 @@
     "cargo2nix": {
       "inputs": {
         "flake-compat": [
-          "benefice-staging",
+          "benefice-production",
           "flake-compat"
         ],
         "flake-utils": [
-          "benefice-staging",
+          "benefice-production",
           "flake-utils"
         ],
         "nixpkgs": [
-          "benefice-staging",
+          "benefice-production",
           "nixpkgs"
         ],
         "rust-overlay": [
-          "benefice-staging",
+          "benefice-production",
           "rust-overlay"
         ]
       },
@@ -81,19 +104,19 @@
     "cargo2nix_2": {
       "inputs": {
         "flake-compat": [
-          "benefice-testing",
+          "benefice-staging",
           "flake-compat"
         ],
         "flake-utils": [
-          "benefice-testing",
+          "benefice-staging",
           "flake-utils"
         ],
         "nixpkgs": [
-          "benefice-testing",
+          "benefice-staging",
           "nixpkgs"
         ],
         "rust-overlay": [
-          "benefice-testing",
+          "benefice-staging",
           "rust-overlay"
         ]
       },
@@ -114,6 +137,39 @@
     "cargo2nix_3": {
       "inputs": {
         "flake-compat": [
+          "benefice-testing",
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "benefice-testing",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "benefice-testing",
+          "nixpkgs"
+        ],
+        "rust-overlay": [
+          "benefice-testing",
+          "rust-overlay"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655189312,
+        "narHash": "sha256-gpJ57OgIebUpO+7F00VltxSEy6dz2x6HeJ5BcRM8rDA=",
+        "owner": "cargo2nix",
+        "repo": "cargo2nix",
+        "rev": "c149357cc3d17f2849c73eb7a09d07a307cdcfe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cargo2nix",
+        "repo": "cargo2nix",
+        "type": "github"
+      }
+    },
+    "cargo2nix_4": {
+      "inputs": {
+        "flake-compat": [
           "drawbridge-production",
           "flake-compat"
         ],
@@ -144,7 +200,7 @@
         "type": "github"
       }
     },
-    "cargo2nix_4": {
+    "cargo2nix_5": {
       "inputs": {
         "flake-compat": [
           "drawbridge-staging",
@@ -177,7 +233,7 @@
         "type": "github"
       }
     },
-    "cargo2nix_5": {
+    "cargo2nix_6": {
       "inputs": {
         "flake-compat": [
           "drawbridge-testing",
@@ -215,7 +271,7 @@
         "flake-compat": [
           "flake-compat"
         ],
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "utils": "utils"
       },
       "locked": {
@@ -233,29 +289,6 @@
       }
     },
     "drawbridge-production": {
-      "inputs": {
-        "cargo2nix": "cargo2nix_3",
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_4",
-        "rust-overlay": "rust-overlay_3"
-      },
-      "locked": {
-        "lastModified": 1659692949,
-        "narHash": "sha256-iF2jv+lQMfvQtrTQwMQu+MF1oiqBerRR92RxF3Ykvhw=",
-        "owner": "profianinc",
-        "repo": "drawbridge",
-        "rev": "5ec3f4a47a63b11ffcbb1d7620688eb0f7a7b320",
-        "type": "github"
-      },
-      "original": {
-        "owner": "profianinc",
-        "ref": "v0.2.2",
-        "repo": "drawbridge",
-        "type": "github"
-      }
-    },
-    "drawbridge-staging": {
       "inputs": {
         "cargo2nix": "cargo2nix_4",
         "flake-compat": "flake-compat_4",
@@ -278,7 +311,7 @@
         "type": "github"
       }
     },
-    "drawbridge-testing": {
+    "drawbridge-staging": {
       "inputs": {
         "cargo2nix": "cargo2nix_5",
         "flake-compat": "flake-compat_5",
@@ -287,11 +320,34 @@
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
-        "lastModified": 1661954498,
-        "narHash": "sha256-MXNah6ROLx/NFbLeyXQ0BJjWSBW4fdr9IvYxgm3uW24=",
+        "lastModified": 1659692949,
+        "narHash": "sha256-iF2jv+lQMfvQtrTQwMQu+MF1oiqBerRR92RxF3Ykvhw=",
         "owner": "profianinc",
         "repo": "drawbridge",
-        "rev": "58fe8ddda1dd7d57242d5280fade5c6c4cb82db3",
+        "rev": "5ec3f4a47a63b11ffcbb1d7620688eb0f7a7b320",
+        "type": "github"
+      },
+      "original": {
+        "owner": "profianinc",
+        "ref": "v0.2.2",
+        "repo": "drawbridge",
+        "type": "github"
+      }
+    },
+    "drawbridge-testing": {
+      "inputs": {
+        "cargo2nix": "cargo2nix_6",
+        "flake-compat": "flake-compat_6",
+        "flake-utils": "flake-utils_6",
+        "nixpkgs": "nixpkgs_7",
+        "rust-overlay": "rust-overlay_6"
+      },
+      "locked": {
+        "lastModified": 1663150054,
+        "narHash": "sha256-nHKy1s2cmmyd5WMStXIbr0oW9SMbAj86gP4Dol8eKWU=",
+        "owner": "profianinc",
+        "repo": "drawbridge",
+        "rev": "0caff73cd828ec274c06680adddceddb2fb0967d",
         "type": "github"
       },
       "original": {
@@ -303,16 +359,16 @@
     "enarx": {
       "inputs": {
         "fenix": "fenix",
-        "flake-compat": "flake-compat_6",
-        "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_7"
+        "flake-compat": "flake-compat_7",
+        "flake-utils": "flake-utils_7",
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1662568517,
-        "narHash": "sha256-5LtK9L488xSmy5lqnt8fVjjvce0AZwSeLc441qfJRHg=",
+        "lastModified": 1663160246,
+        "narHash": "sha256-Sg41E7Hyw/tGbt4OxB21EAbEikjKT9y9FVAGwG+DCac=",
         "owner": "enarx",
         "repo": "enarx",
-        "rev": "eff89e2aa738ee28744d3751f9ba1c71d26d66ec",
+        "rev": "7b3f4589918e649b2999dec26679ff042fa3e530",
         "type": "github"
       },
       "original": {
@@ -426,6 +482,22 @@
       }
     },
     "flake-compat_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_11": {
       "flake": false,
       "locked": {
         "lastModified": 1650374568,
@@ -586,6 +658,21 @@
     },
     "flake-utils_10": {
       "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_11": {
+      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -616,11 +703,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -646,11 +733,11 @@
     },
     "flake-utils_5": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -691,11 +778,11 @@
     },
     "flake-utils_8": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -721,11 +808,11 @@
     },
     "nixlib": {
       "locked": {
-        "lastModified": 1662253098,
-        "narHash": "sha256-CU8i1mxM2NxpsMg5nP/LlCNx23zyh7hJIyyuwIU1bww=",
+        "lastModified": 1662858143,
+        "narHash": "sha256-I/1BGOLo2C0gH4PDnUitqJ10oz7pk1PK+wtboTclZvM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2a57bd4b5d090109dbf9593580ef2d1c6bca117f",
+        "rev": "08ace8d434f46a2314366f0a220d2df642ed6a99",
         "type": "github"
       },
       "original": {
@@ -736,11 +823,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1661937934,
-        "narHash": "sha256-9pdD9mh5ag9RRWPJ1DV0Q7wEHt/7yECCN28bq0zI9wc=",
+        "lastModified": 1663061167,
+        "narHash": "sha256-b3r1Ta4TSUe93M5Qeu1yoNvCfC4StIAygXVVF7qWUok=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71d2c6c28c7b7677ea3e65c556e596f9ade324cb",
+        "rev": "a81b6401f6b5503d26918f062d010619f4059032",
         "type": "github"
       },
       "original": {
@@ -751,11 +838,11 @@
     },
     "nixpkgs-22_05": {
       "locked": {
-        "lastModified": 1662221733,
-        "narHash": "sha256-dw1xjYyQ0JidXIpzeQh/gQX+ih1sJO1zBHKs5QSYp8Q=",
+        "lastModified": 1662864125,
+        "narHash": "sha256-AtjyEFK7Zp9+hOOUNO1/YZRADV/wC94R3yeKN8saUK4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "013e8d86d9a3f33074c903c8ffcab0d34087b1ed",
+        "rev": "e6f053b6079c16e7df97531e3e0524ace1304d4d",
         "type": "github"
       },
       "original": {
@@ -782,6 +869,21 @@
     },
     "nixpkgs_11": {
       "locked": {
+        "lastModified": 1656947410,
+        "narHash": "sha256-htDR/PZvjUJGyrRJsVqDmXR8QeoswBaRLzHt13fd0iY=",
+        "owner": "profianinc",
+        "repo": "nixpkgs",
+        "rev": "e8d47977286a44955262adbc76f2c8a66e7419d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "profianinc",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_12": {
+      "locked": {
         "lastModified": 1661452322,
         "narHash": "sha256-af43gLCzk4rPnc8iVwaRS0P+H+leDc9qPACMG8+Yyhc=",
         "owner": "profianinc",
@@ -797,11 +899,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1661937934,
-        "narHash": "sha256-9pdD9mh5ag9RRWPJ1DV0Q7wEHt/7yECCN28bq0zI9wc=",
+        "lastModified": 1663061167,
+        "narHash": "sha256-b3r1Ta4TSUe93M5Qeu1yoNvCfC4StIAygXVVF7qWUok=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71d2c6c28c7b7677ea3e65c556e596f9ade324cb",
+        "rev": "a81b6401f6b5503d26918f062d010619f4059032",
         "type": "github"
       },
       "original": {
@@ -811,6 +913,21 @@
       }
     },
     "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1663061167,
+        "narHash": "sha256-b3r1Ta4TSUe93M5Qeu1yoNvCfC4StIAygXVVF7qWUok=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a81b6401f6b5503d26918f062d010619f4059032",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1648219316,
         "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
@@ -822,21 +939,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1659001090,
-        "narHash": "sha256-GluhtRyXf3bzbQQbsSOJRY7FAR7cMeGhRUcnnJaT99w=",
-        "owner": "profianinc",
-        "repo": "nixpkgs",
-        "rev": "8255afe757589eac479fb2bd87a1ab5cd3a0b51f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "profianinc",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -858,6 +960,21 @@
     },
     "nixpkgs_6": {
       "locked": {
+        "lastModified": 1659001090,
+        "narHash": "sha256-GluhtRyXf3bzbQQbsSOJRY7FAR7cMeGhRUcnnJaT99w=",
+        "owner": "profianinc",
+        "repo": "nixpkgs",
+        "rev": "8255afe757589eac479fb2bd87a1ab5cd3a0b51f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "profianinc",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
         "lastModified": 1661452322,
         "narHash": "sha256-af43gLCzk4rPnc8iVwaRS0P+H+leDc9qPACMG8+Yyhc=",
         "owner": "profianinc",
@@ -871,7 +988,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1660036486,
         "narHash": "sha256-mjLSzeFMxqfIwAOnmPsxV5+UGbXN0VoMMhWnw/JaImk=",
@@ -886,28 +1003,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
-      "locked": {
-        "lastModified": 1662662716,
-        "narHash": "sha256-0HKMMB1BgtFCb4WlWgSMPVbS7Qj+n8xD05AngmwjQnM=",
-        "owner": "profianinc",
-        "repo": "nixpkgs",
-        "rev": "f7ab473737dfd3282b155bc1ae6ad176fdac06cd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "profianinc",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1656947410,
-        "narHash": "sha256-htDR/PZvjUJGyrRJsVqDmXR8QeoswBaRLzHt13fd0iY=",
+        "lastModified": 1662698175,
+        "narHash": "sha256-vtDCfsvd5VXsNr1izet6N4eeTViyMEVYck5clrrmNgk=",
         "owner": "profianinc",
         "repo": "nixpkgs",
-        "rev": "e8d47977286a44955262adbc76f2c8a66e7419d5",
+        "rev": "9d48a9af607c3a26ed78d68c5796430fc24bb441",
         "type": "github"
       },
       "original": {
@@ -918,6 +1020,7 @@
     },
     "root": {
       "inputs": {
+        "benefice-production": "benefice-production",
         "benefice-staging": "benefice-staging",
         "benefice-testing": "benefice-testing",
         "deploy-rs": "deploy-rs",
@@ -925,10 +1028,10 @@
         "drawbridge-staging": "drawbridge-staging",
         "drawbridge-testing": "drawbridge-testing",
         "enarx": "enarx",
-        "flake-compat": "flake-compat_7",
-        "flake-utils": "flake-utils_7",
+        "flake-compat": "flake-compat_8",
+        "flake-utils": "flake-utils_8",
         "nixlib": "nixlib",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_9",
         "sops-nix": "sops-nix",
         "steward-production": "steward-production",
         "steward-staging": "steward-staging",
@@ -1006,20 +1109,20 @@
     "rust-overlay": {
       "inputs": {
         "flake-utils": [
-          "benefice-staging",
+          "benefice-production",
           "flake-utils"
         ],
         "nixpkgs": [
-          "benefice-staging",
+          "benefice-production",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1661915084,
-        "narHash": "sha256-+csJO6Ffp9A51N6GlwrhS+U35STAxNbp42vpKmaBrck=",
+        "lastModified": 1663038100,
+        "narHash": "sha256-DpqF/1FYpUo3Fm54oBaXzdqIG7BuRkHHFOgLM0uVVF0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "790cf08a011248a881a516cadf125bbc47f1a420",
+        "rev": "dbd08f5b5469e1e24f00de45ddc73c26290a2bcb",
         "type": "github"
       },
       "original": {
@@ -1031,20 +1134,20 @@
     "rust-overlay_2": {
       "inputs": {
         "flake-utils": [
-          "benefice-testing",
+          "benefice-staging",
           "flake-utils"
         ],
         "nixpkgs": [
-          "benefice-testing",
+          "benefice-staging",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1661915084,
-        "narHash": "sha256-+csJO6Ffp9A51N6GlwrhS+U35STAxNbp42vpKmaBrck=",
+        "lastModified": 1663038100,
+        "narHash": "sha256-DpqF/1FYpUo3Fm54oBaXzdqIG7BuRkHHFOgLM0uVVF0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "790cf08a011248a881a516cadf125bbc47f1a420",
+        "rev": "dbd08f5b5469e1e24f00de45ddc73c26290a2bcb",
         "type": "github"
       },
       "original": {
@@ -1056,20 +1159,20 @@
     "rust-overlay_3": {
       "inputs": {
         "flake-utils": [
-          "drawbridge-production",
+          "benefice-testing",
           "flake-utils"
         ],
         "nixpkgs": [
-          "drawbridge-production",
+          "benefice-testing",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1659599305,
-        "narHash": "sha256-htzFq5RffyoKSZxiLfpUq5CyhkQwycsXB5ptale5e78=",
+        "lastModified": 1663038100,
+        "narHash": "sha256-DpqF/1FYpUo3Fm54oBaXzdqIG7BuRkHHFOgLM0uVVF0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "28cedcb8dfea9f1b96b0635cf99fe6bdca163f4e",
+        "rev": "dbd08f5b5469e1e24f00de45ddc73c26290a2bcb",
         "type": "github"
       },
       "original": {
@@ -1081,11 +1184,11 @@
     "rust-overlay_4": {
       "inputs": {
         "flake-utils": [
-          "drawbridge-staging",
+          "drawbridge-production",
           "flake-utils"
         ],
         "nixpkgs": [
-          "drawbridge-staging",
+          "drawbridge-production",
           "nixpkgs"
         ]
       },
@@ -1106,6 +1209,31 @@
     "rust-overlay_5": {
       "inputs": {
         "flake-utils": [
+          "drawbridge-staging",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "drawbridge-staging",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1659599305,
+        "narHash": "sha256-htzFq5RffyoKSZxiLfpUq5CyhkQwycsXB5ptale5e78=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "28cedcb8dfea9f1b96b0635cf99fe6bdca163f4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_6": {
+      "inputs": {
+        "flake-utils": [
           "drawbridge-testing",
           "flake-utils"
         ],
@@ -1128,39 +1256,14 @@
         "type": "github"
       }
     },
-    "rust-overlay_6": {
-      "inputs": {
-        "flake-utils": [
-          "steward-production",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "steward-production",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1656989406,
-        "narHash": "sha256-w2oW0C6qRUy/VsTKRFEM/7Xxb+nHM+QkVosA3fMRgBM=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "2be2b68fc248883b82d3c7bfa6e5c0caff68223d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
     "rust-overlay_7": {
       "inputs": {
         "flake-utils": [
-          "steward-staging",
+          "steward-production",
           "flake-utils"
         ],
         "nixpkgs": [
-          "steward-staging",
+          "steward-production",
           "nixpkgs"
         ]
       },
@@ -1179,6 +1282,31 @@
       }
     },
     "rust-overlay_8": {
+      "inputs": {
+        "flake-utils": [
+          "steward-staging",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "steward-staging",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1656989406,
+        "narHash": "sha256-w2oW0C6qRUy/VsTKRFEM/7Xxb+nHM+QkVosA3fMRgBM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "2be2b68fc248883b82d3c7bfa6e5c0caff68223d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_9": {
       "inputs": {
         "flake-utils": [
           "steward-testing",
@@ -1211,11 +1339,11 @@
         "nixpkgs-22_05": "nixpkgs-22_05"
       },
       "locked": {
-        "lastModified": 1662390490,
-        "narHash": "sha256-HnFHRFu0eoB0tLOZRjLgVfHzK+4bQzAmAmHSzOquuyI=",
+        "lastModified": 1662870301,
+        "narHash": "sha256-O+ABD+WzEBLVH6FwxKCIpps0hsR6b5dpYe6fB3e3Ju8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "044ccfe24b349859cd9efc943e4465cc993ac84e",
+        "rev": "20929e1c5722a6db2f2dbe4cd36d4af0de0a9df0",
         "type": "github"
       },
       "original": {
@@ -1227,29 +1355,6 @@
     "steward-production": {
       "inputs": {
         "fenix": "fenix_2",
-        "flake-compat": "flake-compat_8",
-        "flake-utils": "flake-utils_8",
-        "nixpkgs": "nixpkgs_9",
-        "rust-overlay": "rust-overlay_6"
-      },
-      "locked": {
-        "lastModified": 1657025200,
-        "narHash": "sha256-8vn/rTUk3Rh/MJJauiA7m9DtuPBnLgzxsRXGxb3iE4Q=",
-        "owner": "profianinc",
-        "repo": "steward",
-        "rev": "93fce8b4c17d30a80de053229f7ea3a3528697f6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "profianinc",
-        "ref": "v0.1.0",
-        "repo": "steward",
-        "type": "github"
-      }
-    },
-    "steward-staging": {
-      "inputs": {
-        "fenix": "fenix_3",
         "flake-compat": "flake-compat_9",
         "flake-utils": "flake-utils_9",
         "nixpkgs": "nixpkgs_10",
@@ -1270,20 +1375,43 @@
         "type": "github"
       }
     },
-    "steward-testing": {
+    "steward-staging": {
       "inputs": {
-        "fenix": "fenix_4",
+        "fenix": "fenix_3",
         "flake-compat": "flake-compat_10",
         "flake-utils": "flake-utils_10",
         "nixpkgs": "nixpkgs_11",
         "rust-overlay": "rust-overlay_8"
       },
       "locked": {
-        "lastModified": 1661954296,
-        "narHash": "sha256-ZtYdPr1iCsmfIUpzLecwHaQgFDlg6DhbhHu4U5U1vdI=",
+        "lastModified": 1657025200,
+        "narHash": "sha256-8vn/rTUk3Rh/MJJauiA7m9DtuPBnLgzxsRXGxb3iE4Q=",
         "owner": "profianinc",
         "repo": "steward",
-        "rev": "5f2c6bf8dad07434ca1fa98f824d8350739e1c46",
+        "rev": "93fce8b4c17d30a80de053229f7ea3a3528697f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "profianinc",
+        "ref": "v0.1.0",
+        "repo": "steward",
+        "type": "github"
+      }
+    },
+    "steward-testing": {
+      "inputs": {
+        "fenix": "fenix_4",
+        "flake-compat": "flake-compat_11",
+        "flake-utils": "flake-utils_11",
+        "nixpkgs": "nixpkgs_12",
+        "rust-overlay": "rust-overlay_9"
+      },
+      "locked": {
+        "lastModified": 1662885144,
+        "narHash": "sha256-FRnvdaln2yQi+txbowjCAZ5DLwYOup7J1L1qE7b14I4=",
+        "owner": "profianinc",
+        "repo": "steward",
+        "rev": "a4afebd35da47982e156cc48197015021789f6ef",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   description = "Profian Inc Network Infrastructure";
 
-  inputs.benefice-staging.url = github:profianinc/benefice/v0.1.1;
+  inputs.benefice-production.url = github:profianinc/benefice/v0.1.2-rc4;
+  inputs.benefice-staging.url = github:profianinc/benefice/v0.1.2-rc4;
   inputs.benefice-testing.url = github:profianinc/benefice;
   inputs.deploy-rs.inputs.flake-compat.follows = "flake-compat";
   inputs.deploy-rs.url = github:serokell/deploy-rs;

--- a/nixosConfigurations/services/benefice.nix
+++ b/nixosConfigurations/services/benefice.nix
@@ -32,7 +32,7 @@ with flake-utils.lib.system; let
         })
         (mkIf (config.profian.environment == "production") {
           services.benefice.log.level = "info";
-          services.benefice.package = pkgs.benefice.staging; # TODO: Introduce a "production" build
+          services.benefice.package = pkgs.benefice.production;
         })
       ];
     };

--- a/overlays/service.nix
+++ b/overlays/service.nix
@@ -1,4 +1,5 @@
 {
+  benefice-production,
   benefice-staging,
   benefice-testing,
   drawbridge-production,
@@ -12,6 +13,7 @@
 }: final: prev: {
   benefice.testing = benefice-testing.packages.x86_64-linux.benefice-debug-x86_64-unknown-linux-musl;
   benefice.staging = benefice-staging.packages.x86_64-linux.benefice-x86_64-unknown-linux-musl;
+  benefice.production = benefice-production.packages.x86_64-linux.benefice-x86_64-unknown-linux-musl;
 
   drawbridge.testing = drawbridge-testing.packages.x86_64-linux.drawbridge-debug-x86_64-unknown-linux-musl;
   drawbridge.staging = drawbridge-staging.packages.x86_64-linux.drawbridge-x86_64-unknown-linux-musl;


### PR DESCRIPTION
This bumps benefice, and creates a separate production flake input, to keep that separate from staging/testing.

Signed-off-by: Patrick Uiterwijk <patrick@profian.com>