### PR TITLE
fix: add aesmd and pccs requires on benefice sgx

### DIFF
--- a/nixosConfigurations/services/benefice.nix
+++ b/nixosConfigurations/services/benefice.nix
@@ -126,6 +126,11 @@ with flake-utils.lib.system; let
 
       services.enarx.backend = "sgx";
 
+      systemd.services.benefice.requires = [
+        "${pccsServiceName}.service"
+        "aesmd.service"
+      ];
+
       services.pccs.apiKeyFile = intelApiKeyFile;
       services.pccs.enable = true;
 


### PR DESCRIPTION
Signed-off-by: Patrick Uiterwijk <patrick@profian.com>