### PR TITLE
ci: automate flake update

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,28 @@
+name: Update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  nix-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nixbuild/nix-quick-install-action@v18
+        with:
+          nix_conf: experimental-features = nix-command flakes
+      - uses: jessestricker/nix-flake-update@v1
+        id: nix-update
+      - uses: peter-evans/create-pull-request@v4
+        with:
+          branch: nix-update
+          commit-message: ${{ steps.nix-update.outputs.commit-message }}
+          title: ${{ steps.nix-update.outputs.pull-request-title }}
+          body: ${{ steps.nix-update.outputs.pull-request-body }}
+          labels: dependencies, nix
+          assignees: |
+            puiterwijk
+            rvolosatovs
+          signoff: true

--- a/flake.lock
+++ b/flake.lock
@@ -1005,11 +1005,11 @@
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1664887561,
-        "narHash": "sha256-FJR+BhdHl0bAke1Sj87L//odtRP5GUMxmakdPFKH54Y=",
+        "lastModified": 1666175715,
+        "narHash": "sha256-7gWuA8ctPX4+4pXQfcQ1k20VB+g2S+tIyO32o90dyOg=",
         "owner": "profianinc",
         "repo": "nixpkgs",
-        "rev": "b36c086c2c4644e2c84e3b289d5bd07020f5d82b",
+        "rev": "b79f2c25c15ba9259138d855b4353bb9493c8c57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Automatically run `nix flake update`
See example at https://github.com/rvolosatovs/nixify/pull/22

Note that this is just the first step, most notably these PRs do not trigger `push` and `pull_request` workflows until manually closed and reopened. There are better workarounds https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

I think the right thing to do is to use @enarxbot (or `profianbot`?) for this

Included a `nixpkgs` update commit, because we were quite out-of-date compared to upstream and MacOS actions could not fetch `nixUnstable` from caches anymore