### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,15 +32,17 @@ jobs:
         # Infrastructure
         - nixosConfigurations.nuc-1.config.system.build.toplevel
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v17
-    - uses: cachix/cachix-action@v10
+    - uses: nixbuild/nix-quick-install-action@v18
+      with:
+        nix_conf: experimental-features = nix-command flakes
+    - uses: cachix/cachix-action@v11
       with:
         name: enarx
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Build ${{ matrix.output }}
-      run: nix build -L '.#${{ matrix.output }}'
+      run: nix build -L --show-trace '.#${{ matrix.output }}'
 
     # TODO: Build and run a VM, test

--- a/.github/workflows/commisery.yml
+++ b/.github/workflows/commisery.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check-out the repo under $GITHUB_WORKSPACE
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Run Commisery
       uses: enarx/commisery-action@master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,12 +7,14 @@ on:
   workflow_dispatch:
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: staging
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v17
-    - uses: cachix/cachix-action@v10
+    - uses: nixbuild/nix-quick-install-action@v18
+      with:
+        nix_conf: experimental-features = nix-command flakes
+    - uses: cachix/cachix-action@v11
       with:
         name: enarx
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,15 +8,15 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-20.04
+        - ubuntu-latest
         - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v17
-    - uses: cachix/cachix-action@v10
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+    - uses: cachix/cachix-action@v11
       with:
         name: enarx
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix flake check --no-build
+    - run: nix flake check -L --show-trace --keep-going --no-build
     - run: nix fmt

--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -8,15 +8,15 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-20.04
+        - ubuntu-latest
         - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v17
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/install-nix-action@v18
+    - uses: cachix/cachix-action@v11
       with:
         name: enarx
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Start development shell
-      run: nix develop
+      run: nix develop -L


### PR DESCRIPTION
Also switched Linux-only workflows to https://github.com/nixbuild/nix-quick-install-action, which is faster. `macos-latest` is not supported, however https://github.com/nixbuild/nix-quick-install-action/issues/7